### PR TITLE
Introduce NoData mapping

### DIFF
--- a/frontend/src/app/data/calculation/calculation.interfaces.ts
+++ b/frontend/src/app/data/calculation/calculation.interfaces.ts
@@ -26,7 +26,6 @@ export interface Report {
   max: number;
   stddev: number;
   histogram: number[];
-  zeroes: number;
   geographicalArea: number; // m^2
   calculatedPixels: number;
   gridResolution: number; // [m]

--- a/frontend/src/app/report/histogram/histogram-chart/histogram-chart.component.html
+++ b/frontend/src/app/report/histogram/histogram-chart/histogram-chart.component.html
@@ -12,7 +12,6 @@
       + binInfo[i].lowerBound + ' &ndash; ' + binInfo[i + 1].lowerBound + ' : '
       + (bVal | number: '1.0':locale) + '\n'
       + ('report.histogram.cumulative-proportion' | translate) + ' ≥ ' + binInfo[i].cumulativeQuantity + '\n'
-      + ('report.histogram.cumulative-proportion-exclusive' | translate) + ' ≥ ' +  binInfo[i].cumulativeQuantityEx + '\n'
       + ('report.histogram.middle-of-range' | translate) + ' = ' + (binInfo[i].middle | number:'.0':locale ) }}
       </title>
     </path>

--- a/frontend/src/app/report/histogram/histogram-chart/histogram-chart.component.ts
+++ b/frontend/src/app/report/histogram/histogram-chart/histogram-chart.component.ts
@@ -11,7 +11,6 @@ import { formatPercentage } from "@data/calculation/calculation.util";
 export class HistogramChartComponent implements OnInit, OnChanges {
   @Input() bins: number[] = []
   @Input() reportMax!: number;
-  @Input() zeroes!: number;
   @Input() inclusive = false;
   @Input() locale = 'en';
   @Input() algorithm = '';
@@ -41,8 +40,7 @@ export class HistogramChartComponent implements OnInit, OnChanges {
     this.binSz = this.reportMax / 100;
     this.isRarityAdjusted = this.algorithm === 'RarityAdjustedCumulativeImpact';
 
-    const incZero = (this.inclusive ? 0 : this.zeroes),
-          count = this.bins.reduce((a, b) => a + b) + incZero,
+    const count = this.bins.reduce((a, b) => a + b),
           ystep =       // suitable vertical measure interval
             this.bmax < 10 ? 1 :
             this.bmax < 30 ? 5 :
@@ -56,19 +54,17 @@ export class HistogramChartComponent implements OnInit, OnChanges {
             this.bmax < 1000000 ? 100000 :
             500000;
 
-    let acc = this.bins[0] + incZero;
+    let acc = this.bins[0];
 
     this.max = this.bmax < 10 ? 10 :
       (Math.trunc(this.bmax / ystep) + 1) * ystep;
 
-    this.binInfo = this.bins.slice(1).map((b, ix) => {
+    this.binInfo = this.bins.map((b, ix) => {
       acc += b;
-      return this.makeInfo(ix + 1, acc, count);
+      return this.makeInfo(ix, acc, count);
     });
 
-    this.binInfo.unshift(this.makeInfo(0, this.bins[0] + incZero, count));
     this.binInfo.push(this.makeInfo(100, acc, count));
-    this.binInfo[0].lowerBound = !this.inclusive ? 'ε' : this.binInfo[0].lowerBound;
 
     this.segments = [...Array(Math.ceil(this.max / ystep)).keys()]
       .map((v) => {
@@ -118,8 +114,8 @@ export class HistogramChartComponent implements OnInit, OnChanges {
     // "Middle number": arbitrarily prefer an integer value when reasonable
     // Actual values may be expected to be discrete
     const middle = binIndex * this.binSz + (this.binSz / 2);
-    return new BinInfo(this.decimalPipe.transform(binIndex * this.binSz, '1.2-4', this.locale) || '',
-                        acc, this.isRarityAdjusted || this.reportMax < 200 ? middle : Math.round(middle), count, this.zeroes, this.locale)
+    return new BinInfo(this.decimalPipe.transform(binIndex * this.binSz, '1.2-5', this.locale) || '',
+                        acc, this.isRarityAdjusted || this.reportMax < 200 ? middle : Math.round(middle), count, this.locale)
   }
 
   ngOnChanges(): void {
@@ -142,13 +138,11 @@ class Segment {
 class BinInfo {
   lowerBound: string;
   cumulativeQuantity: string;
-  cumulativeQuantityEx: string;
   middle: number;
 
-  constructor(lowerBound: string, cQuantity: number, middle: number, count: number, zeroes: number, locale: string) {
+  constructor(lowerBound: string, cQuantity: number, middle: number, count: number, locale: string) {
     this.lowerBound = lowerBound;
     this.middle = middle;
     this.cumulativeQuantity = formatPercentage(cQuantity / count, 3, locale);
-    this.cumulativeQuantityEx = formatPercentage((cQuantity - zeroes) / (count - zeroes) , 3, locale);
   }
 }

--- a/frontend/src/app/report/histogram/histogram.component.html
+++ b/frontend/src/app/report/histogram/histogram.component.html
@@ -1,14 +1,6 @@
 <h4>{{ title }}</h4>
-<p [ngClass]="{ 'zeroes_detail': true, 'normal': hasZeroes }">{{
-  (hasZeroes ? '(' + (('report.histogram.zeroes-included' | translate) | lowercase) + ')' :
-                      'report.histogram.zeroes-excluded') | translate }}</p>
-<div id="toggleZeroes" (click)="toggleHistogramRange()">{{
-  (hasZeroes ?'report.histogram.exclude-zero' :
-              'report.histogram.include-zero')| translate }}</div>
 <app-histogram-chart
-  [zeroes]="report.zeroes"
-  [inclusive]="hasZeroes"
-  [bins]="this.dbins[!hasZeroes ? 0 : 1]"
+  [bins]="report.histogram"
   [reportMax]="report.max"
   [algorithm]="report.operationName"
   [locale]="locale">

--- a/frontend/src/app/report/histogram/histogram.component.scss
+++ b/frontend/src/app/report/histogram/histogram.component.scss
@@ -6,31 +6,4 @@
     margin: 0.5rem 0;
   }
 
-  p.zeroes_detail {
-    font-size: 1.2rem;
-    margin: 0 0 1rem;
-
-    &.normal {
-      color: #888;
-    }
-  }
-
-  #toggleZeroes {
-    position: absolute;
-    right: 2%;
-    top: 6.7rem;
-    padding: 0.4rem 0.8rem;
-    border: 1px solid gray;
-    cursor: pointer;
-
-    &:hover {
-      background-color: #ecf9e7;
-    }
-  }
-
-  @media print {
-    #toggleZeroes {
-      display: none;
-    }
-  }
 }

--- a/frontend/src/app/report/histogram/histogram.component.ts
+++ b/frontend/src/app/report/histogram/histogram.component.ts
@@ -7,21 +7,8 @@ import { Report } from "@data/calculation/calculation.interfaces";
   styleUrls: ['./histogram.component.scss']
 })
 
-export class HistogramComponent implements OnInit {
+export class HistogramComponent  {
   @Input() title?: string;
   @Input() report!: Report;
   @Input() locale = 'en';
-
-  hasZeroes = false;
-
-  dbins: number[][] = [];
-
-  ngOnInit(): void {
-    this.dbins = [this.report.histogram, this.report.histogram.slice()];
-    this.dbins[1][0] += this.report.zeroes;
-  }
-
-  toggleHistogramRange(): void {
-    this.hasZeroes = !this.hasZeroes;
-  }
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -285,12 +285,7 @@
         "histogram": {
             "caption": "Histogram",
             "interval": "Interval",
-            "zeroes-included": "Full range",
-            "zeroes-excluded": "NB. The histogram excludes zero values",
-            "include-zero": "Include zero",
-            "exclude-zero": "Exclude zero",
             "cumulative-proportion": "Cumulative proportion",
-            "cumulative-proportion-exclusive": "Cum. proportion w/o zeroes",
             "middle-of-range": "Middle of range"
         },
         "highest-impact": {

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -285,12 +285,7 @@
         "histogram": {
             "caption": "Histogramme",
             "interval": "Intervalle",
-            "zeroes-included": "Y compris des zéros",
-            "zeroes-excluded": "REMARQUE: Cet histogramme exclut des zéros",
-            "include-zero": "Inclure zéro",
-            "exclude-zero": "Exclure zéro",
             "cumulative-proportion": "Proportion cumulée",
-            "cumulative-proportion-exclusive": "Proportion cumulée sauf des zéros",
             "middle-of-range": "Milieu de l'intervalle"
         },
         "highest-impact": {

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -282,12 +282,7 @@
         "histogram": {
             "caption": "Histogram",
             "interval": "Intervall",
-            "zeroes-included": "Inklusive nollvärden",
-            "zeroes-excluded": "OBS. Histogrammet exkluderar nollvärden",
-            "include-zero": "Inkludera noll",
-            "exclude-zero": "Exkludera noll",
             "cumulative-proportion": "Kumulativ andel",
-            "cumulative-proportion-exclusive": "Kumulativ andel utom nollvärden",
             "middle-of-range": "Intervallets mittental"
         },
         "highest-impact": {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalcService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalcService.java
@@ -7,7 +7,7 @@ import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.data.geojson.GeoJSONReader;
-import org.geotools.feature.simple.SimpleFeatureImpl;
+import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.geotools.gce.geotiff.GeoTiffWriteParams;
 import org.geotools.gce.geotiff.GeoTiffWriter;
 import org.geotools.geometry.jts.JTS;
@@ -209,7 +209,7 @@ public class CalcService {
             pvg.parameter(
                             AbstractGridFormat.GEOTOOLS_WRITE_PARAMS.getName().toString())
                     .setValue(wp);
-
+            pvg.parameter(GeoTiffFormat.WRITE_NODATA.getName().toString()).setValue(true);
             writer.write(coverage, pvg.values().toArray(new GeneralParameterValue[1]));
             writer.dispose();
         } catch (IOException e) {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalibrationService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalibrationService.java
@@ -1,9 +1,6 @@
 package se.havochvatten.symphony.calculation;
 
 import it.geosolutions.jaiext.stats.Statistics;
-import it.geosolutions.jaiext.stats.StatisticsDescriptor;
-import it.geosolutions.jaiext.zonal.ZonalStatsDescriptor;
-import it.geosolutions.jaiext.zonal.ZoneGeometry;
 import org.apache.commons.lang3.time.StopWatch;
 import org.geotools.coverage.grid.GridCoverage2D;
 

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/NormalizerService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/NormalizerService.java
@@ -1,5 +1,6 @@
 package se.havochvatten.symphony.calculation;
 
+import it.geosolutions.jaiext.stats.Statistics;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,8 +65,10 @@ class AreaNormalizer extends RasterNormalizer {
 
     @Override
     public Double apply(GridCoverage2D coverage, Double ignored) {
-        var extrema = (GridCoverage2D) operations.extrema(coverage);
-        return ((double[]) extrema.getProperty("maximum"))[0];
+        double[] extrema =
+            (double[]) ((Statistics[][])
+                ((GridCoverage2D) operations.extrema(coverage)).getProperty(Statistics.STATS_PROPERTY))[0][0].getResult();
+        return extrema[1];
     }
 }
 

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/jai/CIA/CumulativeImpactOp.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/jai/CIA/CumulativeImpactOp.java
@@ -1,5 +1,6 @@
 package se.havochvatten.symphony.calculation.jai.CIA;
 
+import it.geosolutions.jaiext.range.NoDataContainer;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,8 @@ public class CumulativeImpactOp extends PointOpImage {
     private static final Logger LOG = LoggerFactory.getLogger(CumulativeImpactOp.class);
 
     public final static int TRANSPARENT_VALUE = 0;
+
+    public static final int NODATA_VALUE = -1;
     public final static String IMPACT_MATRIX_PROPERTY_NAME = "se.havochvatten.symphony.impact_matrix";
 
     /** Sensitivity matrix */
@@ -49,6 +52,8 @@ public class CumulativeImpactOp extends PointOpImage {
         this.mask = mask;
         this.ecosystemBands = ecosystems;
         this.pressureBands = pressures;
+
+        setProperty(NoDataContainer.GC_NODATA, new NoDataContainer(NODATA_VALUE));
 
         synchronized (this) {
             this.impactMatrix = new double[pressureBands.length][ecosystemBands.length];
@@ -141,6 +146,8 @@ public class CumulativeImpactOp extends PointOpImage {
                     }
                     /* ... ends here. */
                     dstData[dstPixelOffset] = cumulativeSum; // +0 since band offset=0
+                } else {
+                    dstData[dstPixelOffset] = NODATA_VALUE;
                 }
 
                 ecoPixelOffset += ecoPixelStride;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/jai/CIA/RarityAdjustedCumulativeImpactOp.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/jai/CIA/RarityAdjustedCumulativeImpactOp.java
@@ -96,6 +96,8 @@ public class RarityAdjustedCumulativeImpactOp extends CumulativeImpactOp {
                     }
                     /* ... ends here. */
                     dstData[dstPixelOffset] = cumulativeSum; // +0 since band offset=0
+                } else {
+                    dstData[dstPixelOffset] = NODATA_VALUE;
                 }
 
                 ecoPixelOffset += ecoPixelStride;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/ReportResponseDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/ReportResponseDto.java
@@ -26,8 +26,7 @@ public class ReportResponseDto {
     public double min;
     public double max;
     public double stddev;
-    public int[] histogram;
-    public long zeroes;
+    public double[] histogram;
     public double geographicalArea; // in m²
 
     public long calculatedPixels;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/LegendREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/LegendREST.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.geotools.styling.RasterSymbolizer;
 import org.geotools.styling.StyledLayerDescriptor;
+import se.havochvatten.symphony.dto.ComparisonReportResponseDto;
 import se.havochvatten.symphony.dto.LegendDto;
 import se.havochvatten.symphony.service.PropertiesService;
 
@@ -58,6 +59,7 @@ public class LegendREST {
             }
             legend.colorMap =
 					Arrays.stream(symbolizer.getColorMap().getColorMapEntries())
+                            .skip(type != LegendDto.Type.COMPARISON ? 1 : 0)
 							.map(entry -> new LegendDto.ColorMapEntry(entry, type))
 							.toArray(LegendDto.ColorMapEntry[]::new);
 

--- a/symphony-ws/src/main/resources/styles/ecosystem.xml
+++ b/symphony-ws/src/main/resources/styles/ecosystem.xml
@@ -9,7 +9,8 @@ http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
 		<Rule>
 		  <RasterSymbolizer>
 			<ColorMap type="intervals">
-			  <ColorMapEntry color="#cbff02" quantity="1" opacity="0"/>
+			  <ColorMapEntry color="#000000" quantity="0" opacity="0"/>
+			  <ColorMapEntry color="#f1f68e" quantity="1"/>
 			  <ColorMapEntry color="#cbff02" quantity="5"/>
 			  <ColorMapEntry color="#b6f005" quantity="10"/>
 			  <ColorMapEntry color="#a2e704" quantity="15"/>

--- a/symphony-ws/src/main/resources/styles/pressure.xml
+++ b/symphony-ws/src/main/resources/styles/pressure.xml
@@ -9,7 +9,8 @@ http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
 		<Rule>
 		  <RasterSymbolizer>
 			<ColorMap type="intervals">
-			  <ColorMapEntry color="#0072fc" quantity="1" opacity="0"/>
+			  <ColorMapEntry color="#000000" quantity="0" opacity="0"/>
+			  <ColorMapEntry color="#5871e3" quantity="1"/>
 			  <ColorMapEntry color="#0072fc" quantity="5"/>
 			  <ColorMapEntry color="#03c4ff" quantity="10"/>
 			  <ColorMapEntry color="#00ffc4" quantity="15"/>

--- a/symphony-ws/src/main/resources/styles/result-style.xml
+++ b/symphony-ws/src/main/resources/styles/result-style.xml
@@ -9,7 +9,8 @@ http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
 		<Rule>
 		  <RasterSymbolizer>
 			<ColorMap type="intervals">
-			  <ColorMapEntry color="#0072fc" quantity="0.01" opacity="0"/>
+			  <ColorMapEntry color="#000000" quantity="0.00" opacity="0"/>
+			  <ColorMapEntry color="#5871e3" quantity="0.01"/>
 			  <ColorMapEntry color="#0072fc" quantity="0.05"/>
 			  <ColorMapEntry color="#03c4ff" quantity="0.10"/>
 			  <ColorMapEntry color="#00ffc4" quantity="0.15"/>

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/calculation/NormalizerTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/calculation/NormalizerTest.java
@@ -27,7 +27,7 @@ public class NormalizerTest {
     @Before
     public void setup() throws IOException {
         JAIExt.initJAIEXT();
-
+        /* TODO: Supply a more suitable test raster for the percentile calculation  */
         Hints hints = null; //new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, Boolean.TRUE);
         coverage = new GeoTiffReader(new File(NormalizerTest.class.getClassLoader().
                 getResource("unittest/checkerboard.tif").getFile()), hints).read(null);
@@ -65,11 +65,11 @@ public class NormalizerTest {
     public void percentileNormalizer() {
         factory = mock(NormalizerService.class);
         when(factory.getNormalizer(NormalizationType.PERCENTILE))
-                .thenReturn(new PercentileNormalizer(95, new Operations()));
+                .thenReturn(new PercentileNormalizer(50, new Operations()));
 
         var normalizer = factory.getNormalizer(NormalizationType.PERCENTILE);
         var result = normalizer.apply(coverage, Double.NaN);
 
-        assertEquals(0.005, result.doubleValue(), TOL); // other bands should remain unchanged
+        assertEquals(0.015, result.doubleValue(), TOL); // other bands should remain unchanged
     }
 }


### PR DESCRIPTION
Development in this commit obviously renders the previous separation of zero values (introduced with ad0b6ae) in the report component purposeless, as expected. 

"Show zeroes"-button is accordingly removed.