### PR TITLE
SYM-477: Handle non-projected coordinate system

### DIFF
--- a/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.html
+++ b/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.html
@@ -63,8 +63,9 @@
       <td *ngIf="reports.length==2">{{ relativeDifferencePercentage('stddev') }}</td>
     </tr>
     <tr class="ruled">
-      <th>{{ 'report.cumulative-effect-etc.calculated-area' | translate }}:</th>
-      <td [colSpan]="reports.length === 2 ? 3 : 1">{{ areaKm2 | number: '1.0-2':locale }} {{ 'report.cumulative-effect-etc.km2' | translate }}</td>
+      <th [ngClass]="validArea ? '' : 'invalid'">{{ 'report.cumulative-effect-etc.calculated-area' | translate }}:</th>
+      <td *ngIf="validArea" [colSpan]="reports.length === 2 ? 3 : 1">{{ areaKm2 | number: '1.0-2':locale }} {{ 'report.cumulative-effect-etc.km2' | translate }}</td>
+      <td *ngIf="!validArea" [colSpan]="reports.length === 2 ? 3 : 1" class="invalid" title="{{ 'report.cumulative-effect-etc.no-area-desc' | translate }}">{{ 'report.cumulative-effect-etc.no-area' | translate }}</td>
     </tr>
   </table>
 

--- a/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.scss
+++ b/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/hav-colors';
+
 :host {
   display: block;
   max-width: 300px;
@@ -28,6 +30,11 @@
         padding-left: 0;
         margin-right: 25px;
         width: 10em;
+
+        &.invalid {
+          color: $hav-darkgrey;
+          text-decoration: line-through;
+        }
       }
       th:not(:first-child) {
         text-align: center;
@@ -35,6 +42,14 @@
       td:nth-child(4) {
         text-align: right;
       }
+
+      td {
+        &.invalid {
+          color: $hav-darkgrey;
+          font-style: oblique;
+        }
+      }
+
     }
     tr.ruled>* {
       border-top: 1px solid;

--- a/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.ts
+++ b/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.ts
@@ -18,8 +18,11 @@ export class CumulativeEffectEtcComponent {
   @Input() locale = 'en';
 
   type = NormalizationType; // make enum available to template
+  validArea: boolean;
 
-  constructor(private translate : TranslateService) {}
+  constructor(private translate : TranslateService) {
+    this.validArea = !isNaN(this.area!);
+  }
 
   get areaKm2() {
     return this.area ? this.area / 1e6 : 0;

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -278,6 +278,8 @@
             "std-dev": "Std. Dev",
             "calculated-area": "Calculated area",
             "km2": "km²",
+            "no-area": "N/A",
+            "no-area-desc": "Area cannot be measured",
             "normalization": {
                 "title": "Result colorscale",
                 "domain": "{{ ordinalPercentileValue }} percentile",

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -278,6 +278,8 @@
             "std-dev": "Ecart type",
             "calculated-area": "Surface",
             "km2": "km²",
+            "no-area": "N/A",
+            "no-area-desc": "Étendue indéterminable",
             "normalization": {
                 "title": "Palette de couleurs",
                 "domain": "{{ ordinalPercentileValue }} centile",

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -278,6 +278,8 @@
             "std-dev": "Standardavvikelse",
             "calculated-area": "Beräknad area",
             "km2": "km²",
+            "no-area": "(kan ej beräknas)",
+            "no-area-desc": "Områdets omfattning kan ej bestämmas",
             "normalization": {
                 "title": "Färgkodning maxvärde",
                 "domain": "{{ ordinalPercentileValue }} percentilen",


### PR DESCRIPTION
Simply omit the area calculation altogether when the provided data tiff isn't projected (ie it's unit of measure isn't convertible to metric)