### PR TITLE
More detailed name collision error message

### DIFF
--- a/frontend/src/app/data/area/area.effects.ts
+++ b/frontend/src/app/data/area/area.effects.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import AreaService from './area.service';
 import { AreaActions } from './';
 import { Area, Areas, Feature, NationalArea, NationalAreaState, Polygon, StatePath } from './area.interfaces';
+import { ServerError } from "../message/message.interfaces";
 import { TranslateService } from '@ngx-translate/core';
 import { Store } from "@ngrx/store";
 import { State } from "@src/app/app-reducer";
@@ -111,8 +112,15 @@ export class AreaEffects {
             }
           })
         ),
-        catchError(({ status, error: message }) =>
-          of(AreaActions.createUserDefinedAreaFailure({ error: { status, message } }))
+        catchError(({ status, error: message }) => {
+            const srvError = (message as ServerError),
+                  tmpMessage = this.translateService.instant('map.user-area.create.error.' + srvError.errorCode,
+                    { areaName: name });
+            if(tmpMessage !== srvError.errorCode) {
+              (message as ServerError).errorMessage = tmpMessage;
+            }
+            return of(AreaActions.createUserDefinedAreaFailure({error: { status, message }}))
+          }
         )
       )
     )

--- a/frontend/src/app/shared/popup-message/popup-message.component.html
+++ b/frontend/src/app/shared/popup-message/popup-message.component.html
@@ -16,7 +16,7 @@
         </ng-container>
       </ng-container>
       <h3>{{ messages[0].title || ('popup-message.'+messages[0].type | translate)}}</h3>
-      <p [innerHTML]="messages[0].message"></p>
+      <p *ngFor="let message of messages[0].message.split('\n')" [innerHTML]="message"></p>
     </div>
     <hav-button (click)="removeMessage(messages[0].uuid)">Ok</hav-button>
   </article>

--- a/frontend/src/app/shared/popup-message/popup-message.component.scss
+++ b/frontend/src/app/shared/popup-message/popup-message.component.scss
@@ -29,6 +29,7 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        margin-bottom: 2rem;
 
         svg {
           margin-bottom: 0.6rem;
@@ -40,7 +41,7 @@
         }
 
         p {
-          margin-top: 1rem;
+          margin: 1rem 0 0;
         }
       }
     }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -195,6 +195,9 @@
                     "placeholder": "My area 1",
                     "save": "Save",
                     "close": "Close"
+                },
+                "error": {
+                    "USER_DEF_AREA_NAME_EXISTS" : "You have already saved an area by the name <em>{{ areaName }}</em>.\n\nDelete or rename the previously saved area, or choose another name, and try again."
                 }
             },
             "upload": {

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -195,6 +195,9 @@
                     "placeholder": "Zone 1",
                     "save": "Sauvegarder",
                     "close": "Fermer"
+                },
+                "error": {
+                    "USER_DEF_AREA_NAME_EXISTS" : "Vous avez déjà enregistré une zone nommée <em>{{ areaName }}</em>.\n\nSupprimez ou renommez la zone précédemment enregistrée, ou choisissez un autre nom et réessayez."
                 }
             },
             "upload": {

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -195,6 +195,9 @@
                     "placeholder": "Mitt område 1",
                     "save": "Spara",
                     "close": "Avbryt"
+                },
+                "error": {
+                    "USER_DEF_AREA_NAME_EXISTS" : "Du har redan sparat ett område med namnet <em>{{ areaName }}</em>.\n\nTag bort eller byt namn på det tidigare sparade området, eller välj ett annat namn och försök igen."
                 }
             },
             "upload": {


### PR DESCRIPTION
The more serious issue described in #85 (saving fails for name collisions with _other users_' areas) actually doesn't originate in the source code, but from a faulty table definition in the database.

A unique constraint is defined directly on the user-defined area name, where it should be a composite constraint.
```sql
ALTER TABLE IF EXISTS symphony.userdefarea DROP CONSTRAINT IF EXISTS uda_name;

ALTER TABLE IF EXISTS symphony.userdefarea
    ADD CONSTRAINT uda_name_owner UNIQUE (uda_name, uda_owner)
--  add line below as necessary for the actual tablespace name ("symphony" assumed)
--    USING INDEX TABLESPACE symphony;
```

It's quite possible that the constraint is altogether unnecessary, (there is [a TODO comment](https://github.com/havochvatten/MSP-Symphony/blob/8601ef7c7dd39249543a54ffbca854f2d568bda2/symphony-ws/src/main/java/se/havochvatten/symphony/service/UserDefinedAreaService.java#L122) inside the method for uploading GeoPackage areas, encouraging its removal) which suggests that we may want to come back to this at a later time. I'll bring it up on refinement.