### PR TITLE
SYM-586: Allow inclusion of areas w/o a default matrix coupling in analyses

### DIFF
--- a/frontend/src/app/data/area/area.actions.ts
+++ b/frontend/src/app/data/area/area.actions.ts
@@ -1,5 +1,6 @@
 import { createAction, props } from '@ngrx/store';
-import { Boundary, NationalAreaState, Polygon, StatePath, UserArea, UserAreasState } from './area.interfaces';
+import { Boundary, NationalAreaState, Polygon, StatePath,
+         UserArea, UserAreasState, CalculationAreaSlice } from './area.interfaces';
 import { ErrorMessage } from '@data/message/message.interfaces';
 import { MatrixRef } from "@src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix.interfaces";
 
@@ -31,6 +32,16 @@ export const fetchNationalAreaSuccess = createAction(
 
 export const fetchNationalAreaFailure = createAction(
   '[Area] Fetch national areas data failure',
+  props<{ error: ErrorMessage }>()
+);
+
+export const fetchCalibratedCalculationAreasSuccess = createAction(
+  '[Area] Fetch all calibrated calculation areas for baseline success',
+  props<{ calibratedAreas: CalculationAreaSlice[] }>()
+);
+
+export const fetchCalibratedCalculationAreasFailure = createAction(
+  '[Area] Fetch all calibrated calculation areas for baseline failure',
   props<{ error: ErrorMessage }>()
 );
 

--- a/frontend/src/app/data/area/area.effects.ts
+++ b/frontend/src/app/data/area/area.effects.ts
@@ -10,6 +10,7 @@ import { ServerError } from "../message/message.interfaces";
 import { TranslateService } from '@ngx-translate/core';
 import { Store } from "@ngrx/store";
 import { State } from "@src/app/app-reducer";
+import { UserActions } from "@data/user";
 
 @Injectable()
 export class AreaEffects {
@@ -86,6 +87,21 @@ export class AreaEffects {
       )
     )
   ));
+
+  fetchCalibratedCalculationAreas$ = createEffect(() => this.actions$.pipe(
+    ofType(UserActions.fetchBaselineSuccess),
+    mergeMap(({ baseline }) =>
+        this.areaService.getCalibratedCalculationAreas(baseline!.name).pipe(
+          map(calibratedAreas =>
+            AreaActions.fetchCalibratedCalculationAreasSuccess({ calibratedAreas })
+          ),
+          catchError(({ status, error: message }) =>
+            of(AreaActions.fetchCalibratedCalculationAreasFailure({ error: { status, message } }))
+          )
+        )
+      )
+    )
+  );
 
   createUserDefinedArea$ = createEffect(() => this.actions$.pipe(
     ofType(AreaActions.createUserDefinedArea),

--- a/frontend/src/app/data/area/area.interfaces.ts
+++ b/frontend/src/app/data/area/area.interfaces.ts
@@ -123,6 +123,11 @@ export interface UploadedUserDefinedArea {
   key: string;
 }
 
+export interface CalculationAreaSlice {
+  id: number;
+  name: string;
+}
+
 export interface State {
   areaTypes: string[];
   area: {
@@ -133,4 +138,5 @@ export interface State {
   currentSelection?: StatePath[]; // currentFeature?
   selectionOverlap: boolean;
   selectionMatrices?: AreaMatrixData;
+  calibratedCalculationAreas: CalculationAreaSlice[];
 }

--- a/frontend/src/app/data/area/area.reducers.ts
+++ b/frontend/src/app/data/area/area.reducers.ts
@@ -11,6 +11,7 @@ export const initialState: AreaInterfaces.State = {
   boundaries: [],
   currentSelection: undefined,
   selectionOverlap: false,
+  calibratedCalculationAreas: [],
 };
 
 export const areaReducer = createReducer(
@@ -64,6 +65,10 @@ export const areaReducer = createReducer(
         }),
         {}
       )
+  })),
+  on(AreaActions.fetchCalibratedCalculationAreasSuccess, (state, { calibratedAreas }) => ({
+    ...state,
+    calibratedCalculationAreas: calibratedAreas
   })),
   on(AreaActions.toggleVisibleArea, (state, { statePath }) => {
     return setIn(state, [...statePath, 'visible'], !getIn(state, [...statePath, 'visible'], false));

--- a/frontend/src/app/data/area/area.selectors.ts
+++ b/frontend/src/app/data/area/area.selectors.ts
@@ -49,6 +49,11 @@ export const selectOverlap = createSelector(selectAreaState, state => state.sele
 
 export const selectBoundaries = createSelector(selectAreaState, state => state.boundaries);
 
+export const selectCalibratedCalculationAreas = createSelector(
+  selectAreaState,
+  state => state.calibratedCalculationAreas
+);
+
 export const selectAll = createSelector(
   selectNationalAreas,
   selectUserAreas,

--- a/frontend/src/app/data/area/area.service.ts
+++ b/frontend/src/app/data/area/area.service.ts
@@ -50,4 +50,8 @@ export default class AreaService {
     return this.http.get<{ areas: AreaInterfaces.Boundary[] }>(`${BASE_URL}/areas/boundary`
     );
   }
+
+  getCalibratedCalculationAreas(baselineName: string) {
+    return this.http.get<AreaInterfaces.CalculationAreaSlice[]>(`${BASE_URL}/calculationarea/calibrated/${baselineName}`)
+  }
 }

--- a/frontend/src/app/data/scenario/scenario.actions.ts
+++ b/frontend/src/app/data/scenario/scenario.actions.ts
@@ -93,6 +93,11 @@ export const saveScenarioArea = createAction(
   props<{ areaToBeSaved: ScenarioArea }>()
 );
 
+export const saveArbitraryScenarioAreaMatrixSuccess = createAction(
+    '[Scenario] Save arbitrary scenario area matrix success',
+    props<{ savedScenarioArea: ScenarioArea }>()
+);
+
 export const splitAndReplaceScenarioArea = createAction(
   '[Scenario] Split and replace scenario area',
   props<{ scenarioId: number, replacedAreaId: number, replacementAreas: ScenarioArea[] }>()
@@ -143,9 +148,13 @@ export const changeScenarioNormalization = createAction(
   props<{ normalizationOptions: NormalizationOptions }>()
 );
 
+export const setArbitraryScenarioAreaMatrixAndNormalization = createAction(
+  '[Scenario] Set arbitrary matrix in active scenario area',
+  props<{ areaId: number, matrixId: number, calcAreaId: number }>()
+);
+
 export const changeScenarioAreaMatrix = createAction(
   '[Scenario] Change matrix in active scenario area',
-   //props< { areaTypes: AreaTypeRef, userDefinedMatrix: number } >()
   props< MatrixParameters >()
 );
 

--- a/frontend/src/app/data/scenario/scenario.interfaces.ts
+++ b/frontend/src/app/data/scenario/scenario.interfaces.ts
@@ -38,6 +38,7 @@ export interface ScenarioArea {
   matrix: MatrixParameters;
   scenarioId: number
   excludedCoastal: number | null;
+  customCalcAreaId: number | null;
 }
 
 export interface ScenarioDisplayMeta {

--- a/frontend/src/app/data/scenario/scenario.reducers.ts
+++ b/frontend/src/app/data/scenario/scenario.reducers.ts
@@ -1,5 +1,5 @@
 import { createReducer, on } from '@ngrx/store';
-import { removeIn, setIn, updateIn } from 'immutable';
+import Immutable, { removeIn, setIn, updateIn } from 'immutable';
 import { size } from "lodash";
 
 import { CalculationActions } from '@data/calculation';
@@ -119,6 +119,16 @@ export const scenarioReducer = createReducer(
     ...state,
     scenarios: setIn(state.scenarios, [state.active, 'areas', state.activeArea, 'excludedCoastal'], areaId)
   })),
+  on(ScenarioActions.setArbitraryScenarioAreaMatrixAndNormalization, (state, { areaId, matrixId, calcAreaId }) => {
+    const areaIndex = state.scenarios[state.active!].areas.findIndex(a => a.id === areaId),
+          updatedArea = Immutable.merge(state.scenarios[state.active!].areas[areaIndex],
+              { matrix: { matrixType: 'CUSTOM', matrixId },
+                         customCalcAreaId: calcAreaId } );
+    return (areaIndex === -1) ? state : {
+        ...state,
+        scenarios: setIn(state.scenarios, [state.active, 'areas', areaIndex], updatedArea)
+    }
+  }),
   on(ScenarioActions.updateBandAttribute,(state, { componentType, band, attribute, value }) => {
 
       const change: BandChange = {

--- a/frontend/src/app/data/scenario/scenario.service.ts
+++ b/frontend/src/app/data/scenario/scenario.service.ts
@@ -40,7 +40,9 @@ export class ScenarioService {
       changes: null,
       excludedCoastal: -1, // "magic" number to prevent inclusion by default
       matrix: { matrixType: 'STANDARD', matrixId: undefined },
-      scenarioId: -1 })) as ScenarioArea[]
+      scenarioId: -1,
+      customCalcAreaId: null
+      })) as ScenarioArea[]
   }
 
   create(baseline: Baseline, name: string, areas: ScenarioArea[], normalization: NormalizationOptions,

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.html
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.html
@@ -7,6 +7,7 @@
   <mat-radio-button
     [checked]="matrixOption === 'STANDARD'"
     (change)="check('STANDARD', null)"
+    [disabled]="arbitraryMatrixSelection()"
   > {{ standardLabel }}
   </mat-radio-button>
   <section *ngIf="hasOptionalMatrices()">

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.spec.ts
@@ -55,7 +55,8 @@ describe('MatrixSelectionComponent', () => {
         changes: {},
         matrix: {matrixType: 'STANDARD'},
         scenarioId: -1,
-        excludedCoastal: null
+        excludedCoastal: null,
+        customCalcAreaId: null
       }],
       latestCalculationId: null
     };

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.ts
@@ -20,8 +20,6 @@ import { Subscription } from "rxjs";
   templateUrl: './matrix-selection.component.html',
   styleUrls: ['./matrix-selection.component.scss']
 })
-// TODO We would like to deserialize the matrix options from the scenario so as not to have to load them each time
-// the scenario is opened. But still need to fetch matrices from server (but perhaps in background, i.e. no spinner?)
 export class MatrixSelectionComponent implements OnInit, OnDestroy {
   matrixOption: MatrixOption = 'STANDARD';
   loadingMatrix = false;
@@ -63,6 +61,10 @@ export class MatrixSelectionComponent implements OnInit, OnDestroy {
             [this.matrixData.defaultArea.defaultMatrix,
             ...this.matrixData.defaultArea.commonBaselineMatrices,
             ...this.matrixData.defaultArea.userDefinedMatrices];
+        } else if (this.matrixData && this.matrixData.alternativeMatrices) {
+          this.matrixOptions = [
+              ...this.matrixData.alternativeMatrices.filter(mx => mx.immutable),
+              ...this.matrixData.alternativeMatrices.filter(mx => !mx.immutable)];
         }
         if(this.scenario && this.scenario.areas[this.areaIndex].matrix) { // scenario may be undefined before component initialization
           this.setSelectedCustomMatrix(this.scenario.areas[this.areaIndex].matrix.matrixId);
@@ -183,8 +185,10 @@ export class MatrixSelectionComponent implements OnInit, OnDestroy {
   }
 
   customSelect(matrix: MatrixRef) {
-    this.setSelectedCustomMatrix(matrix.id);
-    this.setMatrix.emit({ matrixType: this.matrixOption, matrixId: matrix.id });
+    if(matrix) {
+      this.setSelectedCustomMatrix(matrix.id);
+      this.setMatrix.emit({ matrixType: this.matrixOption, matrixId: matrix.id });
+    }
   }
 
   async editMatrix() {
@@ -215,5 +219,10 @@ export class MatrixSelectionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.matrixDataSubscription$.unsubscribe();
+  }
+
+  arbitraryMatrixSelection(): boolean {
+    // alternativeMatrices is only set if no default matrix was found on load
+    return !this.matrixData?.defaultArea && !!this.matrixData?.alternativeMatrices;
   }
 }

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix.interfaces.ts
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix.interfaces.ts
@@ -30,6 +30,7 @@ export interface AreaMatrixData {
   defaultArea: DefaultArea | null,
   areaTypes: AreaTypeMatrixMapping[];
   overlap: AreaOverlapFragment[];
+  alternativeMatrices: MatrixRef[] | null
 }
 
 export interface AreaOverlapFragment {

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/scenario-area-detail.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/scenario-area-detail.component.spec.ts
@@ -44,7 +44,8 @@ describe('ScenarioAreaDetailComponent', () => {
         changes: {},
         matrix: {matrixType: 'STANDARD'},
         scenarioId: -1,
-        excludedCoastal: null
+        excludedCoastal: null,
+        customCalcAreaId: null
       }],
       latestCalculationId: null
     };

--- a/frontend/src/app/map-view/scenario/scenario-editor.component.html
+++ b/frontend/src/app/map-view/scenario/scenario-editor.component.html
@@ -5,7 +5,7 @@
 <ng-template #scenario>
   <ng-container *ngIf="getActiveAreaIndex() !== undefined; then scenarioAreaDetail else scenarioDetail"></ng-container>
   <ng-template #scenarioDetail>
-    <app-scenario-detail [scenario]="getActiveScenario()" [deleteAreaDelegate]="confirmDeleteArea"></app-scenario-detail>
+    <app-scenario-detail [scenario]="getActiveScenario()" [deleteAreaDelegate]="confirmDeleteArea" [deleteAreaAction]="deleteAreaAction"></app-scenario-detail>
   </ng-template>
   <ng-template #scenarioAreaDetail>
     <app-scenario-area-detail

--- a/frontend/src/app/map-view/scenario/scenario-editor.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-editor.component.ts
@@ -11,7 +11,6 @@ import { TranslateService } from "@ngx-translate/core";
 import { DialogService } from "@shared/dialog/dialog.service";
 import { Observable } from "rxjs";
 import { MetadataActions } from "@data/metadata";
-import { UserSelectors } from "@data/user";
 
 @Component({
   selector: 'app-scenario-editor',
@@ -71,13 +70,17 @@ export class ScenarioEditorComponent {
             }
           });
       if (confirmDeleteArea) {
-        this.store.dispatch(ScenarioActions.closeActiveScenarioArea());
-        if (scenario.areas.length > 1) {
-          this.store.dispatch(ScenarioActions.deleteScenarioArea({areaId}));
-        } else {
-          this.store.dispatch(ScenarioActions.deleteScenario({scenarioToBeDeleted: scenario}));
-        }
+        this.deleteAreaAction(areaId, scenario);
       }
+    }
+  }
+
+  deleteAreaAction = (areaId: number, scenario: Scenario) => {
+    this.store.dispatch(ScenarioActions.closeActiveScenarioArea());
+    if (scenario.areas.length > 1) {
+      this.store.dispatch(ScenarioActions.deleteScenarioArea({areaId}));
+    } else {
+      this.store.dispatch(ScenarioActions.deleteScenario({ scenarioToBeDeleted: scenario }));
     }
   }
 }

--- a/frontend/src/app/map-view/scenario/scenario-editor.module.ts
+++ b/frontend/src/app/map-view/scenario/scenario-editor.module.ts
@@ -25,6 +25,7 @@ import { MatInputModule } from "@angular/material/input";
 import { TransferChangesComponent } from './transfer-changes/transfer-changes.component';
 import { OverviewInlineBandChangeComponent } from './changes-overview/overview-inline-band-change/overview-inline-band-change.component';
 import { SplitScenarioSettingsComponent } from './split-scenario-settings/split-scenario-settings.component';
+import { SetArbitraryMatrixComponent } from './set-arbitrary-matrix/set-arbitrary-matrix.component';
 
 @NgModule({
   declarations: [
@@ -41,6 +42,7 @@ import { SplitScenarioSettingsComponent } from './split-scenario-settings/split-
     TransferChangesComponent,
     OverviewInlineBandChangeComponent,
     SplitScenarioSettingsComponent,
+    SetArbitraryMatrixComponent,
   ],
     imports: [
         SharedModule,

--- a/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.html
+++ b/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.html
@@ -1,0 +1,36 @@
+<h3>{{ 'map.editor.set-arbitrary-matrix.title' | translate }}</h3>
+<p>{{ 'map.editor.set-arbitrary-matrix.detail' | translate:{ areaName } }}</p>
+<p class="caution">{{ 'map.editor.set-arbitrary-matrix.caution' | translate:{ areaName } }}</p>
+<mat-label>{{ 'map.editor.matrix.sensitivity-matrix' | translate }}</mat-label>
+<mat-form-field>
+  <mat-select [(ngModel)]="selectedMatrix" placeholder="{{
+    'map.editor.set-arbitrary-matrix.select-matrix-placeholder' | translate }}"
+              [panelClass]="'select-sensitivity-matrix-panel'">
+    <mat-option *ngFor="let matrix of matrices" [value]="matrix">
+      {{ matrix.name }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>
+<mat-label>{{ 'map.editor.set-arbitrary-matrix.calculation-area' | translate }}</mat-label>
+<mat-form-field floatLabel="never">
+  <mat-select [(ngModel)]="selectedCalculationArea" placeholder="{{
+    'map.editor.set-arbitrary-matrix.select-area-placeholder' | translate }}"
+              [panelClass]="'select-calibrated-area-panel'"
+              [disabled]="(calibratedAreas$ | async)?.length < 2">
+    <mat-option *ngFor="let area of calibratedAreas$ | async" [value]="area">
+      {{ area.name }}
+      </mat-option>
+  </mat-select>
+</mat-form-field>
+<div class="normalization-note">
+    <p>{{ 'map.editor.set-arbitrary-matrix.normalization-description' | translate:{ percentileValue } }}</p>
+</div>
+<div class="button-pane">
+  <button mat-flat-button [ngClass]="'secondary'" (click)="close()">{{
+    'confirmation-modal.cancel' | translate
+  }}</button>
+  <button mat-flat-button (click)="confirm()"
+          [disabled]="selectedMatrix == null || selectedCalculationArea == null">{{
+    'map.editor.set-arbitrary-matrix.set-matrix-and-normalization' | translate
+  }}</button>
+</div>

--- a/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.scss
+++ b/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.scss
@@ -1,0 +1,52 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  width: 60rem;
+  border-radius: 4px;
+  padding: 2rem;
+
+  h3 {
+    font-size: 2.3rem;
+    font-weight: 600;
+    text-align: center;
+    margin: 0.4rem 0 1.2rem;
+  }
+
+  p {
+    white-space: pre-line;
+    margin: 0 0 1.2rem 0.4rem;
+
+    &.caution {
+      margin-bottom: 1.6rem;
+    }
+  }
+
+  mat-label {
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .normalization-note > p {
+    font-size: 1.33rem;
+    line-height: 1.8rem;
+    font-style: oblique;
+    /* font-weight: 400; */
+    margin: 0;
+  }
+
+  .button-pane {
+    display: flex;
+    justify-content: center;
+    margin-top: 2rem;
+
+    button {
+      margin-left: 1rem;
+    }
+  }
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field {
+  padding: 0 16px 0 4px;
+}

--- a/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.spec.ts
@@ -4,7 +4,7 @@ import { DialogRef } from "@shared/dialog/dialog-ref";
 import { DialogConfig } from "@shared/dialog/dialog-config";
 import { SetArbitraryMatrixComponent } from './set-arbitrary-matrix.component';
 import { TranslateModule } from "@ngx-translate/core";
-
+import { provideMockStore } from '@ngrx/store/testing';
 
 describe('SetArbitraryMatrixComponent', () => {
   let component: SetArbitraryMatrixComponent;
@@ -13,6 +13,7 @@ describe('SetArbitraryMatrixComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+
         TranslateModule.forRoot()
       ],
       providers: [
@@ -26,7 +27,8 @@ describe('SetArbitraryMatrixComponent', () => {
               areaName: ''
             }
           }
-        }
+        },
+        provideMockStore()
       ],
       declarations: [SetArbitraryMatrixComponent]
     });

--- a/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogService } from "@shared/dialog/dialog.service";
+import { DialogRef } from "@shared/dialog/dialog-ref";
+import { DialogConfig } from "@shared/dialog/dialog-config";
+import { SetArbitraryMatrixComponent } from './set-arbitrary-matrix.component';
+import { TranslateModule } from "@ngx-translate/core";
+
+
+describe('SetArbitraryMatrixComponent', () => {
+  let component: SetArbitraryMatrixComponent;
+  let fixture: ComponentFixture<SetArbitraryMatrixComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        DialogService,
+        DialogRef,
+        {
+          provide: DialogConfig,
+          useValue: {
+            data: {
+              matrices: [],
+              areaName: ''
+            }
+          }
+        }
+      ],
+      declarations: [SetArbitraryMatrixComponent]
+    });
+    fixture = TestBed.createComponent(SetArbitraryMatrixComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.ts
+++ b/frontend/src/app/map-view/scenario/set-arbitrary-matrix/set-arbitrary-matrix.component.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+import { Observable } from "rxjs";
+import { Store } from "@ngrx/store";
+import { DialogRef } from "@shared/dialog/dialog-ref";
+import { DialogConfig } from "@shared/dialog/dialog-config";
+import { MatrixRef } from "@src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix.interfaces";
+import { State } from "@src/app/app-reducer";
+import { CalculationAreaSlice } from "@data/area/area.interfaces";
+import { AreaSelectors } from "@data/area";
+
+@Component({
+  selector: 'app-set-arbitrary-matrix',
+  templateUrl: './set-arbitrary-matrix.component.html',
+  styleUrls: ['./set-arbitrary-matrix.component.scss']
+})
+export class SetArbitraryMatrixComponent {
+  matrices: MatrixRef[];
+  areaName!: string;
+  percentileValue: number;
+  selectedMatrix: MatrixRef | null = null;
+  selectedCalculationArea: CalculationAreaSlice | null = null;
+  calibratedAreas$: Observable<CalculationAreaSlice[]>;
+
+  constructor( private dialog: DialogRef,
+               private store: Store<State>,
+               conf: DialogConfig ) {
+    this.matrices = conf.data.matrices || [];
+    this.areaName = conf.data.areaName;
+    this.percentileValue = conf.data.percentileValue;
+    this.calibratedAreas$ = this.store.select(AreaSelectors.selectCalibratedCalculationAreas);
+    this.calibratedAreas$.subscribe((areas) => {
+      if (areas.length > 0) {
+        this.selectedCalculationArea = areas[0];
+      }
+    });
+}
+
+  close() {
+    this.dialog.close(null);
+  }
+
+  confirm() {
+    this.dialog.close([this.selectedMatrix, this.selectedCalculationArea!.id]);
+  }
+}

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -104,6 +104,16 @@
                 "enter-batch-mode": "Enter batch selection mode",
                 "generate": "Generate"
             },
+            "set-arbitrary-matrix": {
+                "title": "Set sensitivity matrix and calculation area",
+                "detail": "No default matrix coupling could be determined for the area \"{{ areaName }}\".\nTo allow the inclusion of this area in a calculation, an arbitrary sensitivity matrix and a area for value normalization* must first be set, manually.",
+                "caution": "Note that cancelling this action will exclude the area from the scenario.",
+                "normalization-description": "*Value normalization means that the result is normalized with respect to the value that {{ percentileValue }}% of data points in the selected area belong to (including coastal areas).",
+                "calculation-area": "Calculation area",
+                "select-matrix-placeholder": "Select sensitivity matrix",
+                "select-area-placeholder": "Select area for normalizing values",
+                "set-matrix-and-normalization": "Set matrix and normalization"
+            },
             "operation": {
                 "title": "Algorithm",
                 "choose": "Choose algorithm",
@@ -133,7 +143,7 @@
                 "no-scenario-selected": "Select a scenario to adjust intensity values"
             },
             "matrix": {
-                "sensitivity-matrix": "Sensitivity Matrix",
+                "sensitivity-matrix": "Sensitivity matrix",
                 "default-matrix": "Default matrix",
                 "alt-matrix": "Alternate matrix",
                 "user-matrix": "User-defined matrix",

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -104,6 +104,16 @@
                 "enter-batch-mode": "Entrer en mode de sélection par lots",
                 "generate": "Générer"
             },
+            "set-arbitrary-matrix": {
+                "title": "Déterminer une matrice de sensibilité et la zone de calcul",
+                "detail": "Aucun couplage matriciel par défaut n'a pu être déterminé pour la zone \"{{ areaName }}\".\nPour que cette zone soit incluse dans un calcul, une matrice de sensibilité arbitraire et une zone pour normalisation des valeurs* doivent d'abord être déterminées.",
+                "caution": "Veuillez noter que si vous annulez cette action, la zone sera exclue du scénario.",
+                "normalization-description": "*La normalisation des valeurs signifie que le résultat est normalisé par rapport à la valeur à laquelle {{ percentileValue }}% des points de données de la zone sélectionnée appartiennent (y compris les zones côtières).",
+                "calculation-area": "Zone de calcul",
+                "select-matrix-placeholder": "Sélectionnez une matrice de sensibilité",
+                "select-area-placeholder": "Sélectionnez une zone pour normaliser les valeurs",
+                "set-matrix-and-normalization": "Utiliser cette matrice et zone"
+            },
             "operation": {
                 "title": "Algorithme",
                 "choose": "Choisissez l'algorithme",

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -104,6 +104,16 @@
                 "enter-batch-mode": "Gå till \"batch\"-läget",
                 "generate": "Generera"
             },
+            "set-arbitrary-matrix": {
+                "title": "Välj matris och beräkningsområde",
+                "detail": "Ingen standardmatriskoppling kunde bestämmas för området \"{{ areaName }}\".\nFör att kunna analysera området behöver en godtycklig känslighetsmatris och ett havsplaneområde för värdenormalisering* först väljas.",
+                "caution": "Observera att om du avbryter denna åtgärd kommer området att exkluderas från scenariot.",
+                "normalization-description": "*Värdenormalisering innebär att resultatet normaliseras med avseende på det värde som {{ percentileValue }}% av datapunkterna i det valda området ligger inom (inklusive värden för kustområden).",
+                "calculation-area": "Beräkningsområde",
+                "select-matrix-placeholder": "Välj en matris",
+                "select-area-placeholder": "Välj område för värdenormalisering",
+                "set-matrix-and-normalization": "Spara matris och område"
+            },
             "operation": {
                 "title": "Algoritm",
                 "choose": "Välj algoritm",

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/AreaSelectionResponseDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/AreaSelectionResponseDto.java
@@ -6,37 +6,11 @@ import java.util.List;
 
 public class AreaSelectionResponseDto {
 
-    public static class Matrix {
-        Integer id;
-        String name;
-        boolean immutable;
-
-        public Integer getId() {
-            return id;
-        }
-
-        public void setId(Integer id) {
-            this.id = id;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public boolean isImmutable() { return immutable; }
-
-        public void setImmutable(boolean immutable) { this.immutable = immutable; }
-    }
-
     public static class Area {
         Integer id;
         String name;
-        Matrix defaultMatrix;
-        List<Matrix> matrices;
+        MatrixSelection defaultMatrix;
+        List<MatrixSelection> matrices;
 
         public Integer getId() {
             return id;
@@ -54,15 +28,15 @@ public class AreaSelectionResponseDto {
             this.name = name;
         }
 
-        public Matrix getDefaultMatrix() {
+        public MatrixSelection getDefaultMatrix() {
             return defaultMatrix;
         }
 
-        public void setDefaultMatrix(Matrix defaultMatrix) {
+        public void setDefaultMatrix(MatrixSelection defaultMatrix) {
             this.defaultMatrix = defaultMatrix;
         }
 
-        public List<Matrix> getMatrices() {
+        public List<MatrixSelection> getMatrices() {
             if (matrices == null) {
                 matrices = new ArrayList<>();
             }
@@ -71,8 +45,8 @@ public class AreaSelectionResponseDto {
     }
 
     public static class DefaultArea extends Area {
-        List<Matrix> userDefinedMatrices;
-        List<Matrix> commonBaselineMatrices;
+        List<MatrixSelection> userDefinedMatrices;
+        List<MatrixSelection> commonBaselineMatrices;
 
         public void setAreaAttributes(Area area) {
             this.setId(area.getId());
@@ -81,14 +55,14 @@ public class AreaSelectionResponseDto {
             this.getMatrices().addAll(area.getMatrices());
         }
 
-        public List<Matrix> getUserDefinedMatrices() {
+        public List<MatrixSelection> getUserDefinedMatrices() {
             if (userDefinedMatrices == null) {
                 userDefinedMatrices = new ArrayList<>();
             }
             return userDefinedMatrices;
         }
 
-        public List<Matrix> getCommonBaselineMatrices() {
+        public List<MatrixSelection> getCommonBaselineMatrices() {
             if (commonBaselineMatrices == null) {
                 commonBaselineMatrices = new ArrayList<>();
             }
@@ -136,12 +110,13 @@ public class AreaSelectionResponseDto {
 
     public static class AreaOverlapFragment {
         public JsonNode polygon;
-        public Matrix defaultMatrix;
+        public MatrixSelection defaultMatrix;
     }
 
     DefaultArea defaultArea;
     List<AreaTypeArea> areaTypes;
     List<AreaOverlapFragment> overlap;
+    List<MatrixSelection> alternativeMatrices; // set only if no matrices are found
 
     public DefaultArea getDefaultArea() {
         return defaultArea;
@@ -153,6 +128,10 @@ public class AreaSelectionResponseDto {
 
     public void setOverlap(List<AreaOverlapFragment> areaOverlapFragments) {
         this.overlap = areaOverlapFragments;
+    }
+
+    public void setAlternativeMatrices(List<MatrixSelection> alternativeMatrices) {
+        this.alternativeMatrices = alternativeMatrices;
     }
 
     public List<AreaTypeArea> getAreaTypes() {
@@ -167,5 +146,9 @@ public class AreaSelectionResponseDto {
             overlap = new ArrayList<>();
         }
         return overlap;
+    }
+
+    public List<MatrixSelection> getAlternativeMatrices() {
+        return alternativeMatrices;
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/CalculationAreaDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/CalculationAreaDto.java
@@ -1,8 +1,12 @@
 package se.havochvatten.symphony.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonInclude(Include.NON_EMPTY)
 public class CalculationAreaDto {
     Integer id;
     String name;
@@ -50,5 +54,4 @@ public class CalculationAreaDto {
         }
         return polygons;
     }
-
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/MatrixSelection.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/MatrixSelection.java
@@ -1,0 +1,39 @@
+package se.havochvatten.symphony.dto;
+
+public class MatrixSelection {
+    Integer id;
+    String name;
+    boolean immutable;
+
+    public MatrixSelection() {}
+
+    public MatrixSelection(int id, String name, boolean immutable) {
+        this.id = id;
+        this.name = name;
+        this.immutable = immutable;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isImmutable() {
+        return immutable;
+    }
+
+    public void setImmutable(boolean immutable) {
+        this.immutable = immutable;
+    }
+}

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/ScenarioAreaDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/ScenarioAreaDto.java
@@ -22,6 +22,8 @@ public class ScenarioAreaDto implements Serializable {
     private final Integer scenarioId;
     private final Integer excludedCoastal;
 
+    private final Integer customCalcAreaId;
+
     public ScenarioAreaDto() {
         id = 0;
         changes = null;
@@ -29,7 +31,9 @@ public class ScenarioAreaDto implements Serializable {
         matrix = null;
         scenarioId = 0;
         excludedCoastal = null;
+        customCalcAreaId = null;
     }
+
     public ScenarioAreaDto(ScenarioArea area, Integer scenarioId) {
         this.id = area.getId();
         this.changes = area.getChanges();
@@ -37,15 +41,19 @@ public class ScenarioAreaDto implements Serializable {
         this.matrix = area.getMatrix();
         this.scenarioId = scenarioId;
         this.excludedCoastal = area.getExcludedCoastal();
+        this.customCalcAreaId = area.getCustomCalcArea() == null ? null :
+                                area.getCustomCalcArea().getId();
     }
 
-    public ScenarioAreaDto(Integer id, JsonNode changes, JsonNode feature, JsonNode matrix, Integer scenarioId, Integer excludedCoastal) {
+    public ScenarioAreaDto(Integer id, JsonNode changes, JsonNode feature, JsonNode matrix,
+                           Integer scenarioId, Integer excludedCoastal, Integer customCalcAreaId) {
         this.id = id;
         this.changes = changes;
         this.feature = feature;
         this.matrix = matrix;
         this.scenarioId = scenarioId;
         this.excludedCoastal = excludedCoastal;
+        this.customCalcAreaId = customCalcAreaId;
     }
 
     public Integer getId() {
@@ -97,5 +105,9 @@ public class ScenarioAreaDto implements Serializable {
 
     public Integer getExcludedCoastal() {
         return excludedCoastal;
+    }
+
+    public Integer getCustomCalcAreaId() {
+        return customCalcAreaId;
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/ScenarioDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/ScenarioDto.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import se.havochvatten.symphony.calculation.CalcService;
 import se.havochvatten.symphony.entity.BaselineVersion;
 import se.havochvatten.symphony.scenario.Scenario;
-import se.havochvatten.symphony.scenario.ScenarioArea;
 
 import java.io.IOException;
 import java.util.Date;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationArea.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationArea.java
@@ -2,6 +2,7 @@ package se.havochvatten.symphony.entity;
 
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import se.havochvatten.symphony.scenario.ScenarioArea;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -9,7 +10,9 @@ import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "calculationarea")
@@ -18,6 +21,8 @@ import java.util.List;
 		@NamedQuery(name = "CalculationArea.findAll", query = "SELECT c FROM CalculationArea c"),
 		@NamedQuery(name = "CalculationArea.findByBaselineName", query = "SELECT c FROM CalculationArea c " +
 				"WHERE c.defaultSensitivityMatrix.baselineVersion.name = :name"),
+        @NamedQuery(name = "CalculationArea.findCalibratedByBaselineName", query = "SELECT c FROM CalculationArea c " +
+                "WHERE c.defaultSensitivityMatrix.baselineVersion.name = :name AND c.maxValue IS NOT NULL"),
         @NamedQuery(name = "CalculationArea.findByIds", query = "SELECT c FROM CalculationArea c " +
                 "WHERE c.id IN :ids")
 })
@@ -61,7 +66,18 @@ public class CalculationArea implements Serializable {
 	@ManyToOne(optional = true)
 	private AreaType areaType;
 
-	public CalculationArea() {}
+    @OneToMany(mappedBy = "customCalcArea")
+    private Set<ScenarioArea> scenarioareas = new LinkedHashSet<>();
+
+    public Set<ScenarioArea> getScenarioareas() {
+        return scenarioareas;
+    }
+
+    public void setScenarioareas(Set<ScenarioArea> scenarioareas) {
+        this.scenarioareas = scenarioareas;
+    }
+
+    public CalculationArea() {}
 
 	public Integer getId() {
 		return id;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/SensitivityMatrix.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/SensitivityMatrix.java
@@ -2,6 +2,8 @@ package se.havochvatten.symphony.entity;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import se.havochvatten.symphony.dto.CalculationResultSlice;
+import se.havochvatten.symphony.dto.MatrixSelection;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -9,6 +11,7 @@ import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
+import java.util.Date;
 import java.util.List;
 
 @Entity
@@ -27,10 +30,31 @@ import java.util.List;
 						"FROM SensitivityMatrix s WHERE s.owner = :matrixName AND s.owner = :owner AND s" +
 						".baselineVersion" +
 						".name = :baseLineName"),
-		@NamedQuery(name = "SensitivityMatrix.findByBaselineNameAndOwner",
+		@NamedQuery(name = "SensitivityMatrix.findOwnByBaselineNameAndOwner",
 				query = "SELECT s FROM " +
 						"SensitivityMatrix s WHERE s.baselineVersion.name = :name AND s.owner = :owner")
 })
+@NamedNativeQuery(name = "SensitivityMatrix.findAllByBaselineNameAndOwner",
+        query = "SELECT sensm_id id, sensm_name name, (sensm_owner IS NULL) immutable FROM sensitivitymatrix s " +
+                "WHERE s.sensm_bver_id = " +
+                    "(SELECT bver_id FROM baselineversion b " +
+                    " WHERE b.bver_name = :name) " +
+                "AND (s.sensm_owner = :owner OR s.sensm_owner IS NULL)",
+        resultSetMapping = "MatrixSelectionMapping"
+)
+
+@SqlResultSetMapping(
+    name = "MatrixSelectionMapping",
+    classes = @ConstructorResult(
+        targetClass = MatrixSelection.class,
+        columns = {
+            @ColumnResult(name = "id", type = Integer.class),
+            @ColumnResult(name = "name", type = String.class),
+            @ColumnResult(name = "immutable", type = Boolean.class)
+        }
+    )
+)
+
 public class SensitivityMatrix implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/exception/SymphonyModelErrorCode.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/exception/SymphonyModelErrorCode.java
@@ -44,6 +44,7 @@ public enum SymphonyModelErrorCode implements SymphonyErrorCode {
     GEOPACKAGE_REPROJECTION_FAILED("GEOPACKAGE_REPROJECTION_FAILED", "Failed reprojection GeoPackage polygon"),
     MATRIX_NOT_SET("MATRIX_NOT_SET", "Calculation failed, matrix parameters not correctly set for area"),
     BATCH_CALCULATION_JOB_RUNNING("BATCH_CALCULATION_JOB_RUNNING", "Cannot delete unfinished batch calculation"),
+    NO_DEFAULT_MATRIX_FOUND("NO_DEFAULT_MATRIX_FOUND", "No matrix found for area"),
     OTHER_ERROR("OTHER_ERROR", "Other error");
 
     private final String key;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/mapper/AreaSelectionResponseDtoMapper.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/mapper/AreaSelectionResponseDtoMapper.java
@@ -1,6 +1,7 @@
 package se.havochvatten.symphony.mapper;
 
 import se.havochvatten.symphony.dto.AreaSelectionResponseDto;
+import se.havochvatten.symphony.dto.MatrixSelection;
 import se.havochvatten.symphony.entity.AreaType;
 import se.havochvatten.symphony.entity.CalcAreaSensMatrix;
 import se.havochvatten.symphony.entity.CalculationArea;
@@ -16,9 +17,9 @@ public class AreaSelectionResponseDtoMapper {
                                                     List<CalcAreaSensMatrix> userDefinedMatrices,
                                                     List<CalcAreaSensMatrix> commonBaselineMatrices) throws SymphonyStandardAppException {
         AreaSelectionResponseDto resp = new AreaSelectionResponseDto();
-        List<AreaSelectionResponseDto.Matrix> userDefinedMatrixDtos =
+        List<MatrixSelection> userDefinedMatrixDtos =
 				mapToCalcAreaSensMatrixDtos(userDefinedMatrices, false);
-        List<AreaSelectionResponseDto.Matrix> commonBaselineMatrixDtos =
+        List<MatrixSelection> commonBaselineMatrixDtos =
                 mapToCalcAreaSensMatrixDtos(commonBaselineMatrices, true);
         AreaSelectionResponseDto.DefaultArea defaultAreaDto = new AreaSelectionResponseDto.DefaultArea();
         defaultAreaDto.setAreaAttributes(mapToAreaDto(defaultArea));
@@ -57,8 +58,8 @@ public class AreaSelectionResponseDtoMapper {
         return areaDto;
     }
 
-    private static List<AreaSelectionResponseDto.Matrix> mapToCalcAreaSensMatrixDtos(List<CalcAreaSensMatrix> calcAreaSensMatrices, boolean publicMatrices) {
-        List<AreaSelectionResponseDto.Matrix> dtos = new ArrayList<>();
+    private static List<MatrixSelection> mapToCalcAreaSensMatrixDtos(List<CalcAreaSensMatrix> calcAreaSensMatrices, boolean publicMatrices) {
+        List<MatrixSelection> dtos = new ArrayList<>();
         calcAreaSensMatrices.forEach(m -> {
             boolean include =
 					!publicMatrices || (publicMatrices && m.getSensitivityMatrix() != null && m.getSensitivityMatrix().getOwner() == null);
@@ -69,17 +70,15 @@ public class AreaSelectionResponseDtoMapper {
         return dtos;
     }
 
-    private static AreaSelectionResponseDto.Matrix mapCalcAreaSensMatrixToDto(CalcAreaSensMatrix calcAreaSensMatrix) {
-        AreaSelectionResponseDto.Matrix dto = new AreaSelectionResponseDto.Matrix();
-        dto.setId(calcAreaSensMatrix.getSensitivityMatrix().getId());
-        dto.setName(calcAreaSensMatrix.getSensitivityMatrix().getName());
-        dto.setImmutable(calcAreaSensMatrix.getSensitivityMatrix().getOwner() == null);
-        return dto;
+    private static MatrixSelection mapCalcAreaSensMatrixToDto(CalcAreaSensMatrix calcAreaSensMatrix) {
+        return new MatrixSelection(
+            calcAreaSensMatrix.getSensitivityMatrix().getId(),
+            calcAreaSensMatrix.getSensitivityMatrix().getName(),
+            calcAreaSensMatrix.getSensitivityMatrix().getOwner() == null);
     }
 
-    public static AreaSelectionResponseDto.Matrix mapSensitivityMatrixToDto(SensitivityMatrix sensitivityMatrix) {
-        AreaSelectionResponseDto.Matrix dto = new AreaSelectionResponseDto.Matrix();
-        ;
+    public static MatrixSelection mapSensitivityMatrixToDto(SensitivityMatrix sensitivityMatrix) {
+        MatrixSelection dto = new MatrixSelection();
         if (sensitivityMatrix != null) {
             dto.setId(sensitivityMatrix.getId());
             dto.setName(sensitivityMatrix.getName());

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/mapper/CalculationAreaMapper.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/mapper/CalculationAreaMapper.java
@@ -13,9 +13,7 @@ import java.util.List;
 public class CalculationAreaMapper {
 
     public static CalculationAreaDto mapToDto(CalculationArea calculationArea) {
-        CalculationAreaDto calculationAreaDto = new CalculationAreaDto();
-        calculationAreaDto.setId(calculationArea.getId());
-        calculationAreaDto.setName(calculationArea.getName());
+        CalculationAreaDto calculationAreaDto = mapToSparseDto(calculationArea);
         calculationAreaDto.setCareaDefault(calculationArea.isCareaDefault());
         calculationAreaDto.setDefaultSensitivityMatrixId(calculationArea.getDefaultSensitivityMatrix() == null ? null : calculationArea.getDefaultSensitivityMatrix().getId());
         calculationAreaDto.getPolygons().addAll(mapPolygonToDto(calculationArea.getCaPolygonList()));
@@ -45,6 +43,13 @@ public class CalculationAreaMapper {
             caPolygons.add(caPolygon);
         }
         return caPolygons;
+    }
+
+    public static CalculationAreaDto mapToSparseDto(CalculationArea calculationArea) {
+        CalculationAreaDto calculationAreaDto = new CalculationAreaDto();
+        calculationAreaDto.setId(calculationArea.getId());
+        calculationAreaDto.setName(calculationArea.getName());
+        return calculationAreaDto;
     }
 
     private static List<CaPolygonDto> mapPolygonToDto(List<CaPolygon> caPolygons) {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/Scenario.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/Scenario.java
@@ -17,8 +17,6 @@ import se.havochvatten.symphony.entity.CalculationResult;
 
 import javax.persistence.*;
 import javax.persistence.Entity;
-import javax.persistence.NamedNativeQueries;
-import javax.persistence.NamedNativeQuery;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -122,7 +120,7 @@ public class Scenario implements Serializable, BandChangeEntity {
 
     public Scenario() {}
 
-    public Scenario(ScenarioDto dto) {
+    public Scenario(ScenarioDto dto, ScenarioService service) {
         id = dto.id;
         owner = dto.owner;
         timestamp = new Date();
@@ -132,7 +130,15 @@ public class Scenario implements Serializable, BandChangeEntity {
         normalization = dto.normalization;
         ecosystemsToInclude = dto.ecosystemsToInclude;
         pressuresToInclude = dto.pressuresToInclude;
-        areas.addAll(Arrays.stream(dto.areas).map(a -> new ScenarioArea(a, this)).toList());
+
+        for(ScenarioAreaDto a : dto.areas) {
+            ScenarioArea area = new ScenarioArea(a, this);
+            if(a.getCustomCalcAreaId() != null) {
+                service.updateArea(area, a.getCustomCalcAreaId());
+            }
+            this.areas.add(area);
+        }
+
         operation = dto.operation;
     }
 
@@ -162,7 +168,8 @@ public class Scenario implements Serializable, BandChangeEntity {
                     a.getFeatureJson(),
                     a.getMatrix(),
                     null,
-                    a.getExcludedCoastal()), this));
+                    a.getExcludedCoastal(),
+                    a.getCustomCalcArea().getId()), this));
         }
     }
 

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioArea.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioArea.java
@@ -12,6 +12,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import se.havochvatten.symphony.dto.LayerType;
 import se.havochvatten.symphony.dto.MatrixParameters;
 import se.havochvatten.symphony.dto.ScenarioAreaDto;
+import se.havochvatten.symphony.entity.CalculationArea;
 
 import javax.persistence.*;
 import javax.persistence.Entity;
@@ -73,6 +74,10 @@ public class ScenarioArea implements BandChangeEntity {
     @Basic
     @Column(name = "excluded_coastal")
     private Integer excludedCoastal;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_calcarea")
+    private CalculationArea customCalcArea = null;
 
     public ScenarioArea() {
 
@@ -172,6 +177,14 @@ public class ScenarioArea implements BandChangeEntity {
 
     public void setScenario(Scenario scenario) {
         this.scenario = scenario;
+    }
+
+    public CalculationArea getCustomCalcArea() {
+        return customCalcArea;
+    }
+
+    public void setCustomCalcArea(CalculationArea customCalcArea) {
+        this.customCalcArea = customCalcArea;
     }
 
     public ScenarioArea(ScenarioAreaDto dto, Scenario scenario) {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import org.apache.commons.lang3.tuple.Pair;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridGeometry2D;
@@ -13,7 +12,6 @@ import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.LiteShape2;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
-import org.hibernate.engine.spi.Mapping;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeature;
@@ -26,6 +24,7 @@ import se.havochvatten.symphony.calculation.Operations;
 import se.havochvatten.symphony.dto.LayerType;
 import se.havochvatten.symphony.dto.ScenarioAreaDto;
 import se.havochvatten.symphony.dto.ScenarioDto;
+import se.havochvatten.symphony.entity.CalculationArea;
 import se.havochvatten.symphony.service.CalculationAreaService;
 import se.havochvatten.symphony.util.Util;
 
@@ -103,6 +102,15 @@ public class ScenarioService {
         em.merge(updated);
         em.flush();
         return updated;
+    }
+
+    @Transactional
+    public ScenarioArea updateArea(ScenarioArea updated, Integer calculationAreaId) {
+        if(calculationAreaId != null) {
+            CalculationArea calculationArea = calculationAreaService.findCalculationArea(calculationAreaId);
+            updated.setCustomCalcArea(calculationArea);
+        }
+        return updateArea(updated);
     }
 
     public void delete(Principal principal, int id) {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/SensMatrixService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/SensMatrixService.java
@@ -39,7 +39,17 @@ public class SensMatrixService {
 
     public List<SensMatrixDto> findSensMatrixDtosByOwner(String baselineName, Principal principal, String preferredLanguage) {
         List<SensMatrixDto> sensMatrixDtos = new ArrayList<>();
-        List<SensitivityMatrix> matrices = em.createNamedQuery("SensitivityMatrix.findByBaselineNameAndOwner")
+        List<SensitivityMatrix> matrices = em.createNamedQuery("SensitivityMatrix.findOwnByBaselineNameAndOwner")
+                .setParameter("name", baselineName)
+                .setParameter("owner", principal.getName())
+                .getResultList();
+        matrices.forEach(s -> sensMatrixDtos.add(EntityToSensMatrixDtoMapper.map(s, preferredLanguage)));
+        return sensMatrixDtos;
+    }
+
+    public List<SensMatrixDto> findAllSensMatrixDtosByOwner(String baselineName, Principal principal, String preferredLanguage) {
+        List<SensMatrixDto> sensMatrixDtos = new ArrayList<>();
+        List<SensitivityMatrix> matrices = em.createNamedQuery("SensitivityMatrix.findAllByBaselineNameAndOwner")
                 .setParameter("name", baselineName)
                 .setParameter("owner", principal.getName())
                 .getResultList();

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/CalculationAreaREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/CalculationAreaREST.java
@@ -57,6 +57,25 @@ public class CalculationAreaREST {
         return Response.ok(calculationAreaDto).build();
     }
 
+    @GET
+    @Path("calibrated/{baselineName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get all calculation areas for baselineName defined in the system " +
+                          "for which a max value has been set",
+                  response = CalculationArea.class, responseContainer = "List")
+    public Response findCalibratedCalculationAreas(@PathParam("baselineName") String baselineName) {
+        List<CalculationArea> resp = calculationAreaService.findCalibratedCalculationAreas(baselineName);
+
+        if (resp != null) {
+            return Response.ok(resp
+                            .stream()
+                            .map(CalculationAreaMapper::mapToSparseDto)
+                            .collect(Collectors.toUnmodifiableList()))
+                    .build();
+        } else
+            return Response.noContent().build();
+    }
+
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Create a CalculationArea", response = Response.class)

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/mapper/AreaSelectionResponseDtoMapperTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/mapper/AreaSelectionResponseDtoMapperTest.java
@@ -3,6 +3,7 @@ package se.havochvatten.symphony.mapper;
 import org.junit.Before;
 import org.junit.Test;
 import se.havochvatten.symphony.dto.AreaSelectionResponseDto;
+import se.havochvatten.symphony.dto.MatrixSelection;
 import se.havochvatten.symphony.entity.AreaType;
 import se.havochvatten.symphony.entity.CalcAreaSensMatrix;
 import se.havochvatten.symphony.entity.CalculationArea;
@@ -97,7 +98,7 @@ public class AreaSelectionResponseDtoMapperTest {
         assertThat(areaDto.getDefaultMatrix().getName(), is(carea.getDefaultSensitivityMatrix().getName()));
 
         assertThat(areaDto.getMatrices().size(), is(carea.getCalcAreaSensMatrixList().size()));
-        AreaSelectionResponseDto.Matrix areaMatrixDto = areaDto.getMatrices().get(0);
+        MatrixSelection areaMatrixDto = areaDto.getMatrices().get(0);
         SensitivityMatrix calcAreaMatrix = carea.getCalcAreaSensMatrixList().get(0).getSensitivityMatrix();
         assertThat(areaMatrixDto.getId(), is(calcAreaMatrix.getId()));
         assertThat(areaMatrixDto.getName(), is(calcAreaMatrix.getName()));

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/service/CalculationAreaServiceTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/service/CalculationAreaServiceTest.java
@@ -13,6 +13,7 @@ import se.havochvatten.symphony.entity.*;
 import se.havochvatten.symphony.exception.SymphonyModelErrorCode;
 import se.havochvatten.symphony.exception.SymphonyStandardAppException;
 import se.havochvatten.symphony.scenario.Scenario;
+import se.havochvatten.symphony.scenario.ScenarioService;
 
 import javax.persistence.EntityManager;
 import java.io.IOException;
@@ -142,6 +143,7 @@ public class CalculationAreaServiceTest {
     @Test(expected = java.lang.RuntimeException.class)
     public void testValuesSetInGetCalculationAreas() throws IOException, SymphonyStandardAppException {
         CalculationAreaService calculationAreaServiceSpy = Mockito.spy(calculationAreaService);
+        ScenarioService scenarioService = mock(ScenarioService.class);
         int baselineVersionId = 1;
         List<AreaMatrixMapping> relevantSelectedAreaMatrices = new ArrayList<>();
         AreaMatrixMapping areaMatrixMapping1 = new AreaMatrixMapping(3, 2);
@@ -208,14 +210,14 @@ public class CalculationAreaServiceTest {
 
         var areaDto =
             new ScenarioAreaDto(1, mapper.readTree("{}"), mapper.readTree(featureJson),
-                    mapper.readTree("{\"matrixType\": \"STANDARD\"}"), -1, null);
+                    mapper.readTree("{\"matrixType\": \"STANDARD\"}"), -1, null, null);
 
         var testScenario = new ScenarioDto();
         testScenario.name = "TEST-SCENARIO";
         testScenario.baselineId = baselineVersionId;
         testScenario.areas = new ScenarioAreaDto[]{ areaDto };
 
-        var scenario = new Scenario(testScenario);
+        var scenario = new Scenario(testScenario, scenarioService);
 
         calculationAreaServiceSpy.getAreaCalcMatrices(scenario);
 


### PR DESCRIPTION
Functionality allowing areas for which a default sensitivity matrix can not be determined, to be analysed anyway, by setting a matrix manually.
Implemented as a dialog box that is shown on scenario creation, alternately on adding an area to an existing scenario, if an included area is problematic in the described manner.
The modal dialog also requires a "calculation area" to be set before proceeding, for assigning its pre-calibrated normalization value when visualizing results (w/ "nth percentile" normalisation setting).