### PR TITLE
SYM-581: Immediate batch calculation on areas

### DIFF
--- a/frontend/src/app/data/calculation/calculation.interfaces.ts
+++ b/frontend/src/app/data/calculation/calculation.interfaces.ts
@@ -97,11 +97,13 @@ export interface PercentileResponse {
 export interface BatchCalculationProcessEntry {
   id: number;
   cancelled: boolean;
-  currentScenario: number|null;
-  scenarios: number[];
+  currentEntity: number|null;
+  entities: number[];
   calculated: number[];
   failed: number[];
   reports: number|null[];
+  isAreaCalculation: boolean;
+  entityNames: { [key: number]: string };
 }
 
 export interface ComparisonLegendState {

--- a/frontend/src/app/data/calculation/calculation.reducers.ts
+++ b/frontend/src/app/data/calculation/calculation.reducers.ts
@@ -78,10 +78,16 @@ export const calculationReducer = createReducer(
     ...state,
     sortCalculations: sortType
   })),
-  on(CalculationActions.updateBatchProcess, (state, { id, process }) => ({
-    ...state,
-    batchProcesses: setIn(state.batchProcesses, [id], process)
-  })),
+  on(CalculationActions.updateBatchProcess, (state, { id, process }) => {
+    const batchProcess = state.batchProcesses[id];
+
+    return typeof batchProcess === 'undefined' ? {
+      ...state,
+      batchProcesses: setIn(state.batchProcesses, [id], process)
+    } : {
+      ...state,
+      batchProcesses: setIn(state.batchProcesses, [id], {...process, entityNames: batchProcess.entityNames })
+  }}),
   on(CalculationActions.removeBatchProcessSuccess, (state, { id }) => ({
     ...state,
     batchProcesses: setIn(state.batchProcesses, [id], undefined)

--- a/frontend/src/app/data/scenario/scenario.interfaces.ts
+++ b/frontend/src/app/data/scenario/scenario.interfaces.ts
@@ -81,6 +81,11 @@ export interface ScenarioSplitOptions {
   batchSelect: boolean;
 }
 
+export interface ScenarioSplitDialogResult {
+  options: ScenarioSplitOptions;
+  immediate: boolean;
+}
+
 export interface ScenarioSplitResponse {
   scenarioId: number;
   splitScenarioIds: number[];

--- a/frontend/src/app/map-view/batch-progress-display/batch-progress.component.html
+++ b/frontend/src/app/map-view/batch-progress-display/batch-progress.component.html
@@ -4,7 +4,7 @@
         [title]="
         checkCompleted(process) ? '' :
             'map.batch-progress.message' | translate:
-          { count: process.calculated.length, total: process.scenarios.length }"
+          { count: process.calculated.length, total: process.entities.length }"
       >{{ (checkCompleted(process) ?
             (process.cancelled ? 'map.batch-progress.header-cancelled' :
                                  'map.batch-progress.header-finished')   :
@@ -22,17 +22,17 @@
               (click)="removeFinishedProcess(process.id)"
     ></app-icon>
   </div>
-  <div class="batch-scenario" *ngFor="let scenario of process.scenarios; index as i">
+  <div class="batch-scenario" *ngFor="let entity of process.entities; index as i">
     <span class="batch-scenario-name">{{
-      (scenarioNames | async)!.get(scenario)
+      process.entityNames[entity]
     }}</span>
-    <mat-spinner *ngIf="process.currentScenario === scenario" [diameter]="14"></mat-spinner>
+    <mat-spinner *ngIf="process.currentEntity === entity" [diameter]="14"></mat-spinner>
     <app-icon [iconType]="'report'"
-              *ngIf="(process.calculated.includes(scenario))"
+              *ngIf="(process.calculated.includes(entity))"
               (click)="showReport(process.reports[i])"
               class="calculation-report"></app-icon>
     <app-icon [iconType]="'cross'"
-              *ngIf="(process.failed.includes(scenario))"
+              *ngIf="(process.failed.includes(entity))"
               class="calculation-failed"
               ></app-icon>
   </div>

--- a/frontend/src/app/map-view/batch-progress-display/batch-progress.component.ts
+++ b/frontend/src/app/map-view/batch-progress-display/batch-progress.component.ts
@@ -20,7 +20,6 @@ import { DialogService } from "@shared/dialog/dialog.service";
 export class BatchProgressComponent {
 
   processes$: Observable<BatchCalculationProcessEntry[]>;
-  scenarioNames: Observable<Map<number, string>>;
 
   constructor(private store : Store<State>,
               private batchStatusService: BatchStatusService,
@@ -28,11 +27,10 @@ export class BatchProgressComponent {
               private translateService: TranslateService,
               private moduleRef: NgModuleRef<never>) {
     this.processes$ = this.store.select(CalculationSelectors.selectBatchProcesses);
-    this.scenarioNames = this.store.select(ScenarioSelectors.selectScenarioNamesIndexed);
     this.processes$.subscribe(processes => {
         for(const bcp of processes) {
             if(bcp) {
-                if (bcp.currentScenario === null && bcp.calculated.length + bcp.failed.length === 0) {
+                if (bcp.currentEntity === null && bcp.calculated.length + bcp.failed.length === 0) {
                     this.batchStatusService.connect(bcp.id)
                 }
             }
@@ -49,7 +47,7 @@ export class BatchProgressComponent {
   }
 
   checkCompleted(process: BatchCalculationProcessEntry): boolean {
-    return process.calculated.length + process.failed.length === process.scenarios.length;
+    return process.calculated.length + process.failed.length === process.entities.length;
   }
 
   removeFinishedProcess(id: number) {

--- a/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.html
+++ b/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.html
@@ -27,7 +27,7 @@
         class="batch-options-button"
         *ngIf="scenario.areas.length > 1"
         [label]="'map.editor.split-scenario-settings.title' | translate"
-        (iconClick)="openSplitOptions()">
+        (iconClick)="openSplitDialog()">
       </app-icon-button>
       <app-add-scenario-areas
         [disabled]="(calculating$ | async) || (areaMatricesLoading$ | async)"

--- a/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.ts
@@ -25,8 +25,7 @@ import { ScenarioActions, ScenarioSelectors } from '@data/scenario';
 import { fetchAreaMatrices } from "@data/scenario/scenario.actions";
 import {
   ChangesProperty,
-  Scenario, ScenarioArea,
-  ScenarioSplitOptions,
+  Scenario, ScenarioArea, ScenarioSplitDialogResult
 } from '@data/scenario/scenario.interfaces';
 import { convertMultiplierToPercent } from '@data/metadata/metadata.selectors';
 import { ScenarioService } from "@data/scenario/scenario.service";
@@ -372,8 +371,8 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
     }
   }
 
-  async openSplitOptions(): Promise<void> {
-    const splitOptions = await this.dialogService.open<ScenarioSplitOptions>(
+  async openSplitDialog(): Promise<void> {
+    const splitDialogResult = await this.dialogService.open<ScenarioSplitDialogResult>(
       SplitScenarioSettingsComponent,
       this.moduleRef,
       { data: {
@@ -384,12 +383,16 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
         }}
     );
 
-    if (splitOptions) {
-      if(splitOptions.batchSelect) {
+    if (splitDialogResult) {
+      if(splitDialogResult.immediate) {
+        this.calcService.queueBatchCalculation([this.scenario.id], splitDialogResult.options);
+      } else {
+        if(splitDialogResult.options.batchSelect) {
           this.store.dispatch(ScenarioActions.closeActiveScenario());
+        }
+        this.store.dispatch(ScenarioActions.splitScenarioForBatch(
+          { scenarioId : this.scenario.id, options: splitDialogResult.options }));
       }
-      this.store.dispatch(ScenarioActions.splitScenarioForBatch(
-        { scenarioId : this.scenario.id, options: splitOptions }));
     }
   }
 

--- a/frontend/src/app/map-view/scenario/scenario-list/scenario-list.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-list/scenario-list.component.ts
@@ -137,15 +137,7 @@ export class ScenarioListComponent extends Listable implements OnDestroy {
 
   triggerBatchRun = async () => {
     if(this.isBatchMode() && this.selectedBatchIds.length > 1) {
-      this.calculationService.queueBatchCalculation(this.selectedBatchIds).pipe()
-        .subscribe({
-          next: (qbr) => {
-            if(qbr) {
-              this.store.dispatch(CalculationActions.updateBatchProcess({ id: qbr.id, process: qbr }));
-            }
-          }
-        }
-      );
+      this.calculationService.queueBatchCalculation(this.selectedBatchIds);
     }
   }
 

--- a/frontend/src/app/map-view/scenario/split-scenario-settings/split-scenario-settings.component.html
+++ b/frontend/src/app/map-view/scenario/split-scenario-settings/split-scenario-settings.component.html
@@ -12,8 +12,11 @@
   'map.editor.split-scenario-settings.enter-batch-mode' | translate
   }}</mat-checkbox>
 <section class="buttons">
-  <button mat-flat-button (click)="confirmSplitScenario()" [ngClass]="'primary'" >
-    {{ 'confirmation-modal.confirm' | translate }}
+  <button mat-flat-button (click)="splitScenario()" [ngClass]="'primary'" >
+    {{ 'map.editor.split-scenario-settings.generate' | translate }}
+  </button>
+  <button mat-flat-button (click)="batchCalculate()" [ngClass]="'primary-alt'" >
+    {{ 'map.editor.split-scenario-settings.batch-calculate' | translate }}
   </button>
   <button mat-flat-button (click)="dialog.close()" [ngClass]="'secondary'">
     {{ 'confirmation-modal.cancel' | translate }}

--- a/frontend/src/app/map-view/scenario/split-scenario-settings/split-scenario-settings.component.ts
+++ b/frontend/src/app/map-view/scenario/split-scenario-settings/split-scenario-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { DialogRef } from "@shared/dialog/dialog-ref";
 import { DialogConfig } from "@shared/dialog/dialog-config";
-import { ScenarioSplitOptions } from "@data/scenario/scenario.interfaces";
+import { ScenarioSplitDialogResult, ScenarioSplitOptions } from "@data/scenario/scenario.interfaces";
 
 
 @Component({
@@ -28,8 +28,22 @@ export class SplitScenarioSettingsComponent {
     this.noAreaChanges = this.config.data.noAreaChanges;
   }
 
-  confirmSplitScenario() {
-    this.options.batchName = this.scenarioNameInput.nativeElement.value;
-    this.dialog.close(this.options);
+  splitScenario() {
+    const result : ScenarioSplitDialogResult = {
+      options: this.options,
+      immediate: false
+    };
+
+    result.options.batchName = this.scenarioNameInput.nativeElement.value;
+
+    this.dialog.close(result);
   }
+
+  batchCalculate() {
+    this.dialog.close({
+      options: this.options,
+      immediate: true
+    });
+  }
+
 }

--- a/frontend/src/app/socket/batch-status.service.ts
+++ b/frontend/src/app/socket/batch-status.service.ts
@@ -28,38 +28,22 @@ export class BatchStatusService {
         const process : BatchCalculationProcessEntry = JSON.parse(event.data);
         this.store.dispatch(CalculationActions.updateBatchProcess({ id: process.id, process }));
 
-        if(process.currentScenario === null &&
-           process.calculated.length + process.failed.length === process.scenarios.length) {
+        if(process.currentEntity === null &&
+           process.calculated.length + process.failed.length === process.entities.length) {
           this.disconnect(id);
+          this.store.dispatch(CalculationActions.fetchCalculations());
         }
       };
       this.sockets[id].onclose = () => {
         this.disconnect(id);
       };
     }
-
-
-    // this.socket = new WebSocket( 'wss://' + window.location.host + env.socketBaseUrl + '/batch-status/' + id, );
-    //
-    // this.socket.onopen = () => {
-    //   console.log('Connected to batch status service');
-    // };
-    // this.socket.onmessage = (event) => {
-    //   this.statusUpdate$.next(JSON.parse(event.data));
-    // };
-    // this.socket.onclose = () => {
-    //   console.log('Disconnected from batch status service');
-    // };
   }
 
   public disconnect(id:number) {
     if (this.sockets[id]) {
       this.sockets[id].close();
       delete this.sockets[id];
-      // if(this.statusUpdates[id]) {
-      //   this.statusUpdates[id].complete();
-      //   delete this.statusUpdates[id];
-      // }
     }
   }
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -96,13 +96,14 @@
                 "select-area-first-label": "Start by selecting an area"
             },
             "split-scenario-settings": {
-                "title": "Split scenario by area",
-                "detail": "Generate a new scenario for each included area",
+                "title": "Multiple area actions",
+                "detail": "Generate a new scenario for each included area, or run a batch calculation on the included areas individually. Note that the latter action will not generate new scenarios.",
                 "set-batch-name": "Batch name to use for generated scenarios",
                 "apply-scenario-changes": "Apply scenario-level intensity changes",
-                "apply-area-changes": "Apply specific area changes to their corresponding scenarios",
-                "enter-batch-mode": "Enter batch selection mode",
-                "generate": "Generate"
+                "apply-area-changes": "Apply specific area changes to their corresponding scenarios/calculations",
+                "enter-batch-mode": "Enter batch selection mode (applicable to \"Generate\" action only)",
+                "generate": "Generate",
+                "batch-calculate": "Calculate"
             },
             "set-arbitrary-matrix": {
                 "title": "Set sensitivity matrix and calculation area",

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -97,7 +97,7 @@
             },
             "split-scenario-settings": {
                 "title": "Multiple area actions",
-                "detail": "Generate a new scenario for each included area, or run a batch calculation on the included areas individually. Note that the latter action will not generate new scenarios.",
+                "detail": "Generate a new scenario for each included area or run a batch calculation on the included areas individually. Note that the latter action will not generate new scenarios.",
                 "set-batch-name": "Batch name to use for generated scenarios",
                 "apply-scenario-changes": "Apply scenario-level intensity changes",
                 "apply-area-changes": "Apply specific area changes to their corresponding scenarios/calculations",

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -96,13 +96,14 @@
                 "select-area-first-label": "Sélectionnez d'abord une zone."
             },
             "split-scenario-settings": {
-                "title": "Scénarios à partir de zones",
-                "detail": "Générer un nouveau scénario pour chaque zone incluse dans le scénario en cours.",
+                "title": "Actions multi-zones",
+                "detail": "Générer un nouveau scénario pour chaque zone incluse dans le scénario en cours, ou lancez un \"calcul par lots\" sur les zones incluses. Notez que cette dernière action ne génère pas de nouveaux scénarios",
                 "set-batch-name": "Nom du calcul par lots",
                 "apply-scenario-changes": "Dupliquer les paramètres d'intensité du scénario",
-                "apply-area-changes": "Appliquer les paramètres spécifiques à la zone aux scénarios correspondants",
-                "enter-batch-mode": "Entrer en mode de sélection par lots",
-                "generate": "Générer"
+                "apply-area-changes": "Appliquer les paramètres spécifiques à la zone aux scénarios/calculs correspondants",
+                "enter-batch-mode": "Entrer en mode de sélection par lots (l'action \"Générer\" uniquement)",
+                "generate": "Générer",
+                "batch-calculate": "Calculer"
             },
             "set-arbitrary-matrix": {
                 "title": "Déterminer une matrice de sensibilité et la zone de calcul",

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -96,13 +96,14 @@
                 "select-area-first-label": "Markera först ett område"
             },
             "split-scenario-settings": {
-                "title": "Scenarier från områden",
-                "detail": "Generera ett nytt scenario för varje område som omfattas av det aktuella",
+                "title": "Åtgärder för områdesgrupp",
+                "detail": "Generera ett nytt scenario för varje område som omfattas av det aktuella, eller kör en \"batch\"-beräkning på de ingående områdena. Observera att den senare åtgärden inte genererar nya scenarion.",
                 "set-batch-name": "Namn på \"batch\"-beräkning",
                 "apply-scenario-changes": "Applicera gemensamma förekomständringar",
-                "apply-area-changes": "Applicera områdesspecifika inställningar på dess motsvarande scenarier",
-                "enter-batch-mode": "Gå till \"batch\"-läget",
-                "generate": "Generera"
+                "apply-area-changes": "Applicera områdesspecifika inställningar på dess motsvarande scenarier/beräkningar",
+                "enter-batch-mode": "Gå till \"batch\"-läget (gäller endast \"Generera\")",
+                "generate": "Generera",
+                "batch-calculate": "Beräkna"
             },
             "set-arbitrary-matrix": {
                 "title": "Välj matris och beräkningsområde",

--- a/frontend/src/styles/hav-colors.scss
+++ b/frontend/src/styles/hav-colors.scss
@@ -74,6 +74,7 @@ $medium-gray: #818181;
 $darker-gray: #6a6a6a;
 $light-bluegray: #d9e7ed;
 $lighter-yellow: #fdf9f1;
+$hav-ext-emerald-hover: #198660;
 
 /* Extracted from obsolete hav-components library */
 

--- a/frontend/src/styles/mat-hav-component.scss
+++ b/frontend/src/styles/mat-hav-component.scss
@@ -61,6 +61,18 @@ button.mdc-button.mat-mdc-unelevated-button.mat-primary {
     }
   }
 
+  &.primary-alt {
+    background-color: $hav-ext-emerald;
+    color: white;
+    border-color: $hav-ext-emerald;
+
+    &:hover {
+      background-color: $hav-ext-emerald-hover;
+      border-color: $hav-ext-emerald-hover;
+      color: white !important;
+    }
+  }
+
   &.secondary, &.basic {
     background-color: white;
     color: $primary-border-blue;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalculationREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalculationREST.java
@@ -27,8 +27,7 @@ import se.havochvatten.symphony.entity.CalculationResult;
 import se.havochvatten.symphony.exception.SymphonyModelErrorCode;
 import se.havochvatten.symphony.exception.SymphonyStandardAppException;
 import se.havochvatten.symphony.exception.SymphonyStandardSystemException;
-import se.havochvatten.symphony.scenario.ScenarioService;
-import se.havochvatten.symphony.scenario.ScenarioSnapshot;
+import se.havochvatten.symphony.scenario.*;
 import se.havochvatten.symphony.service.DataLayerService;
 import se.havochvatten.symphony.service.PropertiesService;
 import se.havochvatten.symphony.web.WebUtil;
@@ -116,7 +115,7 @@ public class CalculationREST {
         var watch = new StopWatch();
         watch.start();
         logger.info("Performing "+CalcService.operationName(persistedScenario.getOperation())+" calculation for " + persistedScenario.getName() + "...");
-        CalculationResult result = calcService.calculateScenarioImpact(persistedScenario);
+        CalculationResult result = calcService.calculateScenarioImpact(persistedScenario, false);
         watch.stop();
         logger.log(Level.INFO, "DONE ({0} ms)", watch.getTime());
 
@@ -269,13 +268,13 @@ public class CalculationREST {
 
         RasterNormalizer normalizer = normalizationFactory.getNormalizer(scenario.getNormalization().type);
 
-        int[] areas = this.calculationResult.getAreaMatrixMap().keySet().stream().sorted().mapToInt(i -> i).toArray();
+        int[] areas = scenario.getAreaMatrixMap().keySet().stream().sorted().mapToInt(i -> i).toArray();
         int areaIndex = 0;
 
         RenderedImage[] renderedImages = new RenderedImage[areas.length];
 
         for(int areaId : areas) {
-            Double normalizationValue = normalizer.apply(coverage, this.calculationResult.getNormalizationValue()[areaIndex]);
+            Double normalizationValue = normalizer.apply(coverage, scenario.getNormalizationValue()[areaIndex]);
             renderedImages[areaIndex] = renderAreaImage(scenario.getAreas().get(areaId).getFeature(), normalizationValue);
             ++areaIndex;
         }
@@ -367,17 +366,57 @@ public class CalculationREST {
             throw new NotAuthorizedException("Null principal");
 
         int[] idArray = intArrayParam(ids);
+        Map<Integer, String> scenarioNames = new HashMap<>();
 
         for(int id : idArray) {
             var persistedScenario = scenarioService.findById(id);
             if (!persistedScenario.getOwner().equals(req.getUserPrincipal().getName()))
                 throw new ForbiddenException("User not owner of scenario");
+            scenarioNames.put(id, persistedScenario.getName());
         }
 
-        BatchCalculation queuedBatchCalculation = calcService.queueBatchCalculation(idArray, req.getUserPrincipal().getName());
+        BatchCalculation queuedBatchCalculation =
+            calcService.queueBatchCalculation(idArray, req.getUserPrincipal().getName(), null);
         logger.log(Level.INFO, "Queuing batch calculation for ids: {0}", Arrays.toString(idArray));
 
-        return new BatchCalculationDto(queuedBatchCalculation);
+        return new BatchCalculationDto(queuedBatchCalculation, scenarioNames);
+    }
+
+    @POST
+    @Path("/batch/areas/{scenarioId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed("GRP_SYMPHONY")
+    @ApiOperation(value = "Queues batch run of scenario area calculations for the given scenario", response = BatchCalculationDto.class)
+    public BatchCalculationDto queueAreaBatchCalculation(@Context HttpServletRequest req, @PathParam("scenarioId") Integer id,
+                                                         ScenarioSplitOptions options) {
+        if (req.getUserPrincipal() == null)
+            throw new NotAuthorizedException("Null principal");
+
+        Scenario persistedScenario = null;
+
+        Map<Integer, String> areaNames = new HashMap<>();
+
+        if(id != null) {
+            persistedScenario = scenarioService.findById(id);
+            if (!persistedScenario.getOwner().equals(req.getUserPrincipal().getName()))
+                throw new ForbiddenException("User not owner of scenario");
+        }
+
+        if (persistedScenario == null)
+            throw new BadRequestException();
+
+        for(ScenarioArea area : persistedScenario.getAreas()) {
+            areaNames.put(area.getId(), area.getName());
+        }
+
+        int[] idArray = areaNames.keySet().stream().mapToInt(i -> i).toArray();
+
+        BatchCalculation queuedBatchCalculation =
+            calcService.queueBatchCalculation(idArray, req.getUserPrincipal().getName(), options);
+        logger.log(Level.INFO, "Queuing batch area calculation for ids: {0}", Arrays.toString(idArray));
+
+        return new BatchCalculationDto(queuedBatchCalculation, areaNames);
     }
 
     @POST
@@ -433,7 +472,7 @@ public class CalculationREST {
     public List<CalculationResultSlice> getCalculationsWithMatchingGeometry(@Context HttpServletRequest req,
                                                                             @PathParam("id") int id) {
         var base = CalcUtil.getCalculationResultFromSessionOrDb(id, req.getSession(),
-            calcService).orElseThrow(javax.ws.rs.NotFoundException::new);
+            calcService).orElseThrow(NotFoundException::new);
         verifyAccessToCalculation(base, req.getUserPrincipal());
 
         return calcService.findAllMatchingCalculationsByUser(req.getUserPrincipal(), base);
@@ -447,7 +486,7 @@ public class CalculationREST {
     public Response getMask(@Context HttpServletRequest req) {
         var session = req.getSession(false);
         if (session == null)
-            return Response.status(Response.Status.NO_CONTENT).build();
+            return status(Response.Status.NO_CONTENT).build();
         return ok(session.getAttribute("mask"), "image/png").build();
     }
 
@@ -455,10 +494,10 @@ public class CalculationREST {
         logger.info("Diffing base line calculations " + baseId + " against calculation " + relativeId);
 
         var base = CalcUtil.getCalculationResultFromSessionOrDb(baseId, req.getSession(),
-            calcService).orElseThrow(javax.ws.rs.BadRequestException::new);
+            calcService).orElseThrow(BadRequestException::new);
         var scenario =
             CalcUtil.getCalculationResultFromSessionOrDb(relativeId, req.getSession(),
-                calcService).orElseThrow(javax.ws.rs.BadRequestException::new);
+                calcService).orElseThrow(BadRequestException::new);
 
         if (!hasAccess(base, req.getUserPrincipal()) || !hasAccess(scenario, req.getUserPrincipal()))
             throw new NotAuthorizedException("Unauthorized");

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalibrationService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/calculation/CalibrationService.java
@@ -130,7 +130,7 @@ public class CalibrationService {
 
     public double calcPercentileNormalizationValue(HttpServletRequest req, Scenario scenario)
         throws FactoryException, SymphonyStandardAppException, TransformException, IOException {
-        CalculationResult result = calcService.calculateScenarioImpact(scenario);
+        CalculationResult result = calcService.calculateScenarioImpact(scenario, false);
         var coverage = result.getCoverage();
 
         PercentileNormalizer normalizer = (PercentileNormalizer) normalizationFactory.getNormalizer(NormalizationType.PERCENTILE);

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/BatchCalculationDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/BatchCalculationDto.java
@@ -4,23 +4,27 @@ import se.havochvatten.symphony.entity.BatchCalculation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 
 public class BatchCalculationDto {
     private final int id;
-    private final int[] scenarios;
+    private final int[] entities;
     private Integer[] reports;
     private ArrayList<Integer> calculated;
     private ArrayList<Integer> failed;
 
-    private Integer currentScenario;
+    private Integer currentEntity;
+
+    private final Map<Integer, String> entityNames;
 
     private boolean cancelled = false;
 
-    public BatchCalculationDto(BatchCalculation batchCalculation) {
+    public BatchCalculationDto(BatchCalculation batchCalculation, Map<Integer, String> entityNames) {
         this.id = batchCalculation.getId();
-        this.scenarios = batchCalculation.getScenarios();
+        this.entities = batchCalculation.getEntities();
         this.calculated = new ArrayList<>(Arrays.stream(batchCalculation.getCalculated()).boxed().toList());
-        this.reports = new Integer[batchCalculation.getScenarios().length];
+        this.reports = new Integer[batchCalculation.getEntities().length];
+        this.entityNames = entityNames;
         setFailed(batchCalculation.getFailed());
     }
 
@@ -28,8 +32,8 @@ public class BatchCalculationDto {
         return id;
     }
 
-    public int[] getScenarios() {
-        return scenarios;
+    public int[] getEntities() {
+        return entities;
     }
 
     public ArrayList<Integer> getCalculated() { return calculated; }
@@ -38,11 +42,11 @@ public class BatchCalculationDto {
 
     public Integer[] getReports() { return reports; }
 
-    public void setCurrentScenario(Integer currentScenario) {
-        this.currentScenario = currentScenario;
+    public void setCurrentEntity(Integer currentEntity) {
+        this.currentEntity = currentEntity;
     }
 
-    public Integer getCurrentScenario() { return currentScenario; }
+    public Integer getCurrentEntity() { return currentEntity; }
 
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
@@ -54,5 +58,9 @@ public class BatchCalculationDto {
 
     public boolean isCancelled() {
         return cancelled;
+    }
+
+    public Map<Integer, String> getEntityNames() {
+        return entityNames;
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/BatchCalculation.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/BatchCalculation.java
@@ -1,7 +1,10 @@
 package se.havochvatten.symphony.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Type;
+import se.havochvatten.symphony.scenario.ScenarioSplitOptions;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -11,6 +14,9 @@ import java.util.ArrayList;
 @Entity
 @Table(name = "batchcalculation")
 public class BatchCalculation {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "batchcalc_id", nullable = false)
@@ -21,14 +27,14 @@ public class BatchCalculation {
     @Column(name = "owner", nullable = false)
     private String owner;
 
-    @Column(name = "execution_id", nullable = true)
+    @Column(name = "execution_id")
     @ColumnDefault("NULL")
     private Integer executionId;
 
     @NotNull
-    @Column(name = "scenarios", nullable = false)
+    @Column(name = "entities", nullable = false)
     @Type(type = "com.vladmihalcea.hibernate.type.array.IntArrayType")
-    private int[] scenarios;
+    private int[] entities;
 
     @Column(name = "calculated", nullable = false)
     @ColumnDefault("ARRAY[]::integer[]")
@@ -39,6 +45,14 @@ public class BatchCalculation {
     @ColumnDefault("ARRAY[]::integer[]")
     @Type(type = "com.vladmihalcea.hibernate.type.array.IntArrayType")
     private int[] failed = new int[0];
+
+    @NotNull
+    @Column(name = "areas_calculation", nullable = false)
+    private Boolean areasCalculation = false;
+
+    @Column(name = "areas_options", columnDefinition = "json")
+    @Type(type = "json")
+    private JsonNode areasOptions;
 
     public Integer getId() {
         return id;
@@ -64,12 +78,12 @@ public class BatchCalculation {
         this.executionId = executionId;
     }
 
-    public int[] getScenarios() {
-        return scenarios;
+    public int[] getEntities() {
+        return entities;
     }
 
-    public void setScenarios(int[] scenarios) {
-        this.scenarios = scenarios;
+    public void setEntities(int[] entities) {
+        this.entities = entities;
     }
 
     public int[] getCalculated() {
@@ -88,4 +102,18 @@ public class BatchCalculation {
 
     public void setFailed(ArrayList<Integer> failed) { this.failed = failed.stream().mapToInt(i -> i).toArray(); }
 
+    public Boolean isAreasCalculation() { return areasCalculation; }
+
+    public void setAreasCalculation(Boolean areasCalculation) { this.areasCalculation = areasCalculation; }
+
+    public ScenarioSplitOptions getAreasOptions() {
+        if (areasOptions == null) {
+            return null;
+        }
+        return mapper.convertValue(areasOptions, ScenarioSplitOptions.class);
+    }
+
+    public void setAreasOptions(ScenarioSplitOptions areasOptions) {
+        this.areasOptions = mapper.valueToTree(areasOptions);
+    }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationResult.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationResult.java
@@ -130,10 +130,6 @@ public class CalculationResult implements Serializable {
     @Temporal(TemporalType.TIMESTAMP)
     private Date timestamp;
 
-    @Column(name = "cares_normalizationvalue", columnDefinition = "double precision[]")
-    @Type(type = "double-array")
-    private double[] normalizationValue;
-
     @OneToOne
     @NotNull
     private ScenarioSnapshot scenarioSnapshot;
@@ -151,38 +147,12 @@ public class CalculationResult implements Serializable {
     @Transient
     private GridCoverage2D coverage;
 
-    @NotNull
-    @Column(name = "cares_areamatrix_map", nullable = false)
-    @Type(type = "int-array")
-    private int[][] areaMatrixMap;
-
     @Column(name = "cares_image")
     private byte[] imagePNG;
 
     @Column(name = "cares_overflow")
     @Type(type = "com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType")
     private JsonNode overflow;
-
-    public Map<Integer, Integer> getAreaMatrixMap() {
-        Map<Integer, Integer> map = new HashMap<>();
-
-        for (int[] ints : areaMatrixMap) {
-            map.put(ints[0], ints[1]);
-        }
-
-        return map;
-    }
-
-    public void setAreaMatrixMap(Map<Integer, Integer> areaMatrixMap) {
-        int[][] map = new int[areaMatrixMap.size()][2];
-        int i = 0;
-        for (Integer key : areaMatrixMap.keySet()) {
-            map[i][0] = key;
-            map[i][1] = areaMatrixMap.get(key);
-            i++;
-        }
-        this.areaMatrixMap = map;
-    }
 
     public CalculationResult() {}
 
@@ -228,14 +198,6 @@ public class CalculationResult implements Serializable {
 
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
-    }
-
-    public double[] getNormalizationValue() {
-        return normalizationValue;
-    }
-
-    public void setNormalizationValue(double[] value) {
-        this.normalizationValue = value;
     }
 
     public double[][] getImpactMatrix() {
@@ -319,10 +281,6 @@ public class CalculationResult implements Serializable {
     }
 
     public Map<String, String> getOperationOptions() { return operationOptions; }
-
-    public MatrixResponse getMatrixResponse() {
-        return new MatrixResponse(getAreaMatrixMap(), getNormalizationValue());
-    }
 
     @Override
     public int hashCode() {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioArea.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioArea.java
@@ -199,4 +199,9 @@ public class ScenarioArea implements BandChangeEntity {
         this.scenario = scenario;
         excludedCoastal = dto.getExcludedCoastal();
     }
+
+    public String getName() {
+        Object nameValue = getFeature().getProperty("name").getValue();
+        return nameValue == null ? this.scenario.getName() + ": (area)" : nameValue.toString();
+    }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioCopyOptions.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioCopyOptions.java
@@ -13,7 +13,7 @@ public class ScenarioCopyOptions {
     public ScenarioCopyOptions() {}
 
     public ScenarioCopyOptions(ScenarioArea area, ScenarioSplitOptions options) {
-        name = "%s - %s".formatted(options.batchName(), area.getFeature().getProperty("name").getValue().toString());
+        name = "%s - %s".formatted(options.batchName(), area.getName());
         includeScenarioChanges = options.applyScenarioChanges();
         areaChangesToInclude = new int[0];
     }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioService.java
@@ -178,7 +178,7 @@ public class ScenarioService {
                     state,
                     (GridCoverage2D innerState, BandChange bandChange) -> {
                         LOG.info("Applying changes for feature {}: " + bandChange,
-                            area.getFeature().getProperty("name").getValue().toString());
+                            area.getName());
 
                         var multipliers = new double[numBands];
                         Arrays.fill(multipliers, 1.0);  // default to no change
@@ -354,6 +354,12 @@ public class ScenarioService {
                     "Scenario.getEcosystemsToInclude" :
                     "Scenario.getPressuresToInclude"), int[].class)
             .setParameter("scenarioId", activeScenarioId)
+            .getSingleResult();
+    }
+
+    public int[] getAreaIdsForScenario(Integer id) {
+        return em.createNamedQuery("Scenario.getAreaIdsForScenario", int[].class)
+            .setParameter("scenarioId", id)
             .getSingleResult();
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioSplitOptions.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/scenario/ScenarioSplitOptions.java
@@ -1,5 +1,8 @@
 package se.havochvatten.symphony.scenario;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
 public record ScenarioSplitOptions(
     String batchName,
     boolean applyScenarioChanges,

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/ReportService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/ReportService.java
@@ -178,14 +178,14 @@ public class ReportService {
                                 // Round to two decimal places and guard for NaN
                                 // since Math.round(Double.NaN) returns 0
 
-        report.areaMatrices = new ReportResponseDto.AreaMatrix[calc.getAreaMatrixMap().size()];
+        report.areaMatrices = new ReportResponseDto.AreaMatrix[scenario.getAreaMatrixMap().size()];
         int am_ix = 0;
         String matrix, areaName;
 
-        for(int areaId : calc.getAreaMatrixMap().keySet()) {
+        for(int areaId : scenario.getAreaMatrixMap().keySet()) {
             areaName = scenario.getAreas().get(areaId).areaName();
             try {
-                matrix = matrixService.getSensMatrixbyId(calc.getAreaMatrixMap().get(areaId), preferredLanguage).getName();
+                matrix = matrixService.getSensMatrixbyId(scenario.getAreaMatrixMap().get(areaId), preferredLanguage).getName();
             } catch (SymphonyStandardAppException e) {
                 matrix = "<unknown>";
             }


### PR DESCRIPTION
Commit includes changes to the data model: two mapped entity properties (`normalizationValue` and `areaMatrixMap`) are moved from `CalculationResult` into `ScenarioSnapshot`. Mapped property `latestCalculation` is removed from `ScenarioSnapshot`.

Two mapped properties are added to the `BatchCalculation` entity (`areasCalculation` and `areasOptions`). The property `scenarios` on the same entity are renamed to `entities` (so as to reflect that the queued entity ids may represent both `Scenarios` and `ScenarioAreas`)