### PR TITLE
SYM-659: Repair alternative colour scale options

### DIFF
--- a/frontend/src/app/data/calculation/calculation.actions.ts
+++ b/frontend/src/app/data/calculation/calculation.actions.ts
@@ -8,12 +8,17 @@ import {
 } from './calculation.interfaces';
 import { ErrorMessage } from '@data/message/message.interfaces';
 import { SortActionProps } from "@data/common/sorting.interfaces";
+import { Scenario } from "@data/scenario/scenario.interfaces";
 
 export const startCalculation = createAction('[Calculation] Add calculation');
 
+export const calculateActiveScenario = createAction(
+  '[Calculation] Calculate and update active scenario',
+);
+
 export const calculationSucceeded = createAction(
   '[Calculation] Calculation succeeded',
-  props<{calculation: CalculationSlice }>()
+  props<{ calculation: CalculationSlice, savedScenario: Scenario }>()
 );
 
 export const calculationFailed = createAction('[Calculation] Calculation failed',);

--- a/frontend/src/app/data/calculation/calculation.service.ts
+++ b/frontend/src/app/data/calculation/calculation.service.ts
@@ -24,11 +24,11 @@ import { UserSelectors } from "@data/user";
 import { Baseline } from "@data/user/user.interfaces";
 
 export enum NormalizationType {
-  Area = 'AREA',
-  Domain = 'DOMAIN',
-  UserDefined = 'USER_DEFINED',
-  StandardDeviation = 'STANDARD_DEVIATION',
-  Percentile = 'PERCENTILE' // Only used on backend for calibration
+  AREA = 'AREA',
+  DOMAIN = 'DOMAIN',
+  USER_DEFINED = 'USER_DEFINED',
+  STANDARD_DEVIATION = 'STANDARD_DEVIATION',
+  PERCENTILE = 'PERCENTILE' // Only used on backend for calibration
 }
 
 export enum CalcOperation {

--- a/frontend/src/app/data/metadata/metadata.actions.ts
+++ b/frontend/src/app/data/metadata/metadata.actions.ts
@@ -22,6 +22,16 @@ export const fetchMetadataSuccess = createAction(
   }>()
 );
 
+export const fetchSparseMetadataSuccess = createAction(
+  '[Metadata] Fetch metadata success (excluding details)',
+  props<{
+    metadata: {
+      ecoComponent: Groups;
+      pressureComponent: Groups;
+    };
+  }>()
+);
+
 export const fetchMetadataFailure = createAction(
   '[Metadata] Fetch metadata failure',
   props<{ error: ErrorMessage }>()

--- a/frontend/src/app/data/metadata/metadata.reducers.ts
+++ b/frontend/src/app/data/metadata/metadata.reducers.ts
@@ -1,6 +1,6 @@
 import { createReducer, on } from '@ngrx/store';
 import { setIn, updateIn } from 'immutable';
-import { State, Band } from './metadata.interfaces';
+import { State, Band, Groups } from './metadata.interfaces';
 import { MetadataActions, MetadataInterfaces } from './';
 import { ScenarioActions } from "@data/scenario";
 import { getBandPath } from "@data/metadata/metadata.selectors";
@@ -17,6 +17,12 @@ export const metadataReducer = createReducer(
     ECOSYSTEM: metadata.ecoComponent,
     PRESSURE: metadata.pressureComponent
   })),
+  on(MetadataActions.fetchSparseMetadataSuccess, (state, { metadata }) => {
+    return {
+      ECOSYSTEM: mapSelectedToState(state, metadata.ecoComponent).ECOSYSTEM,
+      PRESSURE: mapSelectedToState(state, metadata.pressureComponent).PRESSURE
+    }
+  }),
   on(MetadataActions.selectBand, (state, { band, value }) => {
     return setLayerAttribute(state, band, 'selected', value);
   }),
@@ -39,4 +45,13 @@ function setLayerAttribute(state: State, band: Band, attribute: string, value: u
   // artificial "path" / hierarchy modeled on the previous implementation
   // TODO: Reimplement
   return setIn(state, [ ...getBandPath(band), attribute], value);
+}
+
+function mapSelectedToState(state: State, groups: Groups): State {
+  for(const group of Object.values(groups)) {
+    for(const band of Object.values(group.bands)) {
+      state = setLayerAttribute(state, band, 'selected', band.selected);
+    }
+  }
+  return state;
 }

--- a/frontend/src/app/data/scenario/scenario.actions.ts
+++ b/frontend/src/app/data/scenario/scenario.actions.ts
@@ -36,6 +36,16 @@ export const openScenario = createAction(
   props<{ index: number }>()
 );
 
+export const fetchSingleScenario = createAction(
+    '[Scenario] Fetch single scenario',
+    props<{ scenarioId: number }>()
+  );
+
+export const fetchSingleScenarioSuccess = createAction(
+    '[Scenario] Fetch single scenario success',
+    props<{ scenario: Scenario }>()
+  );
+
 export const openScenarioArea = createAction(
   '[Scenario] Open scenario area',
   props<{ index: number, scenarioIndex: number | null }>()
@@ -69,8 +79,7 @@ export const deleteMultipleScenarios = createAction(
 )
 
 export const saveActiveScenario = createAction(
-  '[Scenario] Save active scenario',
-  props<{ scenarioToBeSaved: Scenario }>()
+  '[Scenario] Save active scenario'
 );
 
 export const saveScenarioSuccess = createAction(
@@ -81,6 +90,10 @@ export const saveScenarioSuccess = createAction(
 export const saveScenarioFailure = createAction(
   '[Scenario] Save scenario failure',
   props<{ error: ErrorMessage }>()
+);
+
+export const saveAndCalculateActiveScenario = createAction(
+  '[Scenario] Save and calculate active scenario',
 );
 
 export const deleteScenarioArea = createAction(

--- a/frontend/src/app/data/scenario/scenario.reducers.ts
+++ b/frontend/src/app/data/scenario/scenario.reducers.ts
@@ -2,7 +2,6 @@ import { createReducer, on } from '@ngrx/store';
 import Immutable, { removeIn, setIn, updateIn } from 'immutable';
 
 import { CalculationActions } from '@data/calculation';
-import { calculationSucceeded } from "@data/calculation/calculation.actions";
 import { BandChange } from "@data/metadata/metadata.interfaces";
 import {
   fetchAreaMatricesFailure,
@@ -37,6 +36,13 @@ export const scenarioReducer = createReducer(
     ...state,
     active: newActiveIndex,
     scenarios }
+  }),
+  on(ScenarioActions.fetchSingleScenarioSuccess, (state, { scenario }) => {
+    const index = state.scenarios.findIndex(s => s.id === scenario.id);
+    return {
+      ...state,
+      scenarios: updateIn(state.scenarios, [index], () => scenario)
+    }
   }),
   on(ScenarioActions.openScenario, (state, { index }) => ({
     ...state,
@@ -76,7 +82,7 @@ export const scenarioReducer = createReducer(
     ...state,
     sortScenarios: sortType
   })),
-  on(ScenarioActions.saveScenarioSuccess, (state, { savedScenario }) => ({
+  on(ScenarioActions.saveScenarioSuccess, CalculationActions.calculationSucceeded, (state, { savedScenario }) => ({
     ...state,
     scenarios: updateIn(state.scenarios, [state.active], () => savedScenario),
   })),
@@ -90,10 +96,6 @@ export const scenarioReducer = createReducer(
     ...state,
     scenarios: updateIn(state.scenarios, [state.active, 'areas'], areas => [...(areas as ScenarioArea[]), ...newAreas]),
     matricesLoading: true
-  })),
-  on(CalculationActions.calculationSucceeded, (state, { calculation }) => ({
-    ...state,
-    scenarios: setIn(state.scenarios, [state.active, 'latestCalculationId'], calculation.id)
   })),
   on(ScenarioActions.changeScenarioName, (state, { name }) => ({
     ...state,
@@ -327,12 +329,6 @@ export const scenarioReducer = createReducer(
       ...state,
       matrixData: setIn(state.matrixData, [areaId], matrixData),
       matricesLoading: loading
-    }
-  }),
-  on(calculationSucceeded, (state, { calculation }) => {
-    return {
-      ...state,
-      scenarios: setIn(state.scenarios, [state.active, 'latestCalculationId'], calculation.id)
     }
   }),
   on(fetchAreaMatricesFailure, state => ({

--- a/frontend/src/app/data/scenario/scenario.service.ts
+++ b/frontend/src/app/data/scenario/scenario.service.ts
@@ -71,6 +71,10 @@ export class ScenarioService {
     return this.http.post<Scenario>(this.scenarioApiBaseUrl+'/'+scenarioId+'/copy', options);
   }
 
+  getSingle(scenarioId: number) {
+    return this.http.get<Scenario>(this.scenarioApiBaseUrl+'/'+scenarioId);
+  }
+
   setScenarioChangeVisibility(feature: GeoJSONFeature) {
     return this.scenarioLayer!.toggleChangeAreaVisibility(feature);
   }

--- a/frontend/src/app/map-view/active-scenario-display/active-scenario-display.component.spec.ts
+++ b/frontend/src/app/map-view/active-scenario-display/active-scenario-display.component.spec.ts
@@ -27,7 +27,7 @@ describe('ActiveScenarioDisplayComponent', () => {
       changes: {},
       ecosystemsToInclude: [],
       name: "",
-      normalization: { type:NormalizationType.Domain },
+      normalization: { type:NormalizationType.DOMAIN },
       pressuresToInclude: [],
       areas: [],
       latestCalculationId: null

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/matrix-selection/matrix-selection.component.spec.ts
@@ -47,7 +47,7 @@ describe('MatrixSelectionComponent', () => {
       changes: {},
       ecosystemsToInclude: [],
       name: "",
-      normalization: { type:NormalizationType.Domain },
+      normalization: { type:NormalizationType.DOMAIN },
       pressuresToInclude: [],
       areas: [{
         id: 1,

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/scenario-area-detail.component.html
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/scenario-area-detail.component.html
@@ -11,18 +11,18 @@
     <div>
       <h3>{{ 'map.editor.normalization.title' | translate }}</h3>
       <span [ngSwitch]="scenario.normalization.type">
-        <ng-container *ngSwitchCase="type.Domain">
+        <ng-container *ngSwitchCase="type.DOMAIN">
           {{ 'map.editor.normalization.domain' | translate:{ ordinalPercentileValue: (percentileValue$ | async) | ordinal:locale } }}
         </ng-container>
-        <ng-container *ngSwitchCase="type.Area">
+        <ng-container *ngSwitchCase="type.AREA">
           {{ 'map.editor.normalization.area' | translate }}
         </ng-container>
-        <ng-container *ngSwitchCase="type.StandardDeviation">
+        <ng-container *ngSwitchCase="type.STANDARD_DEVIATION">
           {{ 'report.cumulative-effect-etc.normalization.mean-plus-stddev' | translate:
           { stddevMultiplier: jsMath.abs(scenario.normalization.stdDevMultiplier),
             positiveOrNegative: scenario.normalization.stdDevMultiplier > 0 ? '+' : '-' } }}
         </ng-container>
-        <ng-container *ngSwitchCase="type.UserDefined">
+        <ng-container *ngSwitchCase="type.USER_DEFINED">
           {{ 'map.editor.normalization.custom' | translate }} = {{
           scenario.normalization.userDefinedValue | number: '1.0-4':locale }}
         </ng-container>

--- a/frontend/src/app/map-view/scenario/scenario-area-detail/scenario-area-detail.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/scenario-area-detail/scenario-area-detail.component.spec.ts
@@ -36,7 +36,7 @@ describe('ScenarioAreaDetailComponent', () => {
       changes: {},
       ecosystemsToInclude: [],
       name: "",
-      normalization: { type:NormalizationType.Domain },
+      normalization: { type:NormalizationType.DOMAIN },
       pressuresToInclude: [],
       areas: [{
         id: 1,

--- a/frontend/src/app/map-view/scenario/scenario-detail/normalization-selection/normalization-selection.component.html
+++ b/frontend/src/app/map-view/scenario/scenario-detail/normalization-selection/normalization-selection.component.html
@@ -4,30 +4,30 @@
   <div class="normalization-form">
     <mat-radio-group [value]="this.options.type">
       <mat-radio-button
-        [value]="NormalizationType.Area"
+        [value]="'AREA'"
         (change)="check($event.value)">
         <span class="normalization-label-text">{{ 'map.editor.normalization.area' | translate }}</span>
       </mat-radio-button>
       <mat-radio-button
-        [value]="NormalizationType.Domain"
+        [value]="'DOMAIN'"
         [disabled]="algorithm === 'RarityAdjustedCumulativeImpact'"
         (change)="check($event.value)"
       ><span class="normalization-label-text">{{ 'map.editor.normalization.domain' | translate : { ordinalPercentileValue: this.percentileValue | ordinal:locale } }}</span>
       </mat-radio-button>
       <mat-radio-button
-        [value]="NormalizationType.StandardDeviation"
+        [value]="'STANDARD_DEVIATION'"
         (change)="check($event.value)">
         <span class="normalization-label-text">{{ 'map.editor.normalization.mean-plus-stddev' | translate }}</span>
         <input type="number" id="stddev-multiplier" [step]="0.01" max="9999.99" min="0"
-               [value]="options.stdDevMultiplier" (input)="onChangeValue(NormalizationType.StandardDeviation, $event)" [disabled]="!showValueField(NormalizationType.StandardDeviation)"
+               [value]="options.stdDevMultiplier" (input)="onChangeValue('STANDARD_DEVIATION', $event)" [disabled]="!showValueField(NormalizationType.STANDARD_DEVIATION)"
         />
       </mat-radio-button>
       <mat-radio-button
-        [value]="NormalizationType.UserDefined"
+        [value]="'USER_DEFINED'"
         (change)="check($event.value)">
         <span class="normalization-label-text">{{ 'map.editor.normalization.custom' | translate }}</span>
-        <input #userDefinedValue type="number" id="user-defined-value" [step]="1" max="9999999" min="1"
-               [value]="options.userDefinedValue" (input)="onChangeValue(NormalizationType.UserDefined, $event)" [disabled]="!showValueField(NormalizationType.UserDefined)"
+        <input type="number" id="user-defined-value" [step]="1" max="9999999" min="1"
+               [value]="options.userDefinedValue" (input)="onChangeValue('USER_DEFINED', $event)" [disabled]="!showValueField(NormalizationType.USER_DEFINED)"
         />
       </mat-radio-button>
     </mat-radio-group>

--- a/frontend/src/app/map-view/scenario/scenario-detail/normalization-selection/normalization-selection.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-detail/normalization-selection/normalization-selection.component.ts
@@ -29,19 +29,19 @@ export class NormalizationSelectionComponent implements OnChanges {
   radioButtons = [
     {
       label: 'map.editor.normalization.domain',
-      value: NormalizationType.Domain
+      value: NormalizationType.DOMAIN
     },
     {
       label: 'map.editor.normalization.area',
-      value: NormalizationType.Area
+      value: NormalizationType.AREA
     },
     {
       label: 'map.editor.normalization.mean-plus-stddev',
-      value: NormalizationType.StandardDeviation
+      value: NormalizationType.STANDARD_DEVIATION
     },
     {
       label: 'map.editor.normalization.custom',
-      value: NormalizationType.UserDefined
+      value: NormalizationType.USER_DEFINED
     }
   ];
 
@@ -49,32 +49,33 @@ export class NormalizationSelectionComponent implements OnChanges {
     return ntype === this.options.type;
   }
 
-  check(target: NormalizationType) {
+  check(ntype: string) {
+    if(!ntype) return;
     this.modeSelectionEvent.emit({
-      type: target,
+      type: NormalizationType[ntype as keyof typeof NormalizationType],
       userDefinedValue: this.options.userDefinedValue,
       stdDevMultiplier: this.options.stdDevMultiplier
     });
   }
 
-  onChangeValue(ntype: NormalizationType, event: Event) {
+  onChangeValue(ntype: string, event: Event) {
     const opts = this.options,
           val = parseFloat((event.target! as HTMLInputElement).value);
 
     this.modeSelectionEvent.emit({
-      type: ntype,
-      userDefinedValue: ntype === NormalizationType.UserDefined ?
+      type: NormalizationType[ntype as keyof typeof NormalizationType],
+      userDefinedValue: ntype === NormalizationType.USER_DEFINED ?
                         val : opts.userDefinedValue,
-      stdDevMultiplier: ntype === NormalizationType.StandardDeviation ?
+      stdDevMultiplier: ntype === NormalizationType.STANDARD_DEVIATION ?
                         val : opts.stdDevMultiplier,
     });
   }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.algorithm?.currentValue === 'RarityAdjustedCumulativeImpact' &&
-      this.options.type === NormalizationType.Domain) {
+      this.options.type === NormalizationType.DOMAIN) {
       this.modeSelectionEvent.emit({
-        type: NormalizationType.Area,
+        type: NormalizationType.AREA,
         userDefinedValue: this.options.userDefinedValue,
         stdDevMultiplier: this.options.stdDevMultiplier
       });

--- a/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.spec.ts
+++ b/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.spec.ts
@@ -68,7 +68,7 @@ describe('ScenarioDetailComponent', () => {
       changes: {},
       ecosystemsToInclude: [],
       name: "",
-      normalization: { type:NormalizationType.Domain },
+      normalization: { type:NormalizationType.DOMAIN },
       pressuresToInclude: [],
       areas: [],
       latestCalculationId: null

--- a/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.ts
@@ -231,24 +231,9 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
   }
 
   calculate() {
+    this.unsaved = false;
     this.store.dispatch(CalculationActions.startCalculation());
-
-    // TODO: call service through rxjs effect and avoid code repetition (ScenarioEffects)
-    this.store.select(MetadataSelectors.selectSelectedComponents).pipe(
-      take(1))
-      .subscribe((selectedComponents: { ecoComponent: Band[], pressureComponent: Band[] }) => {
-        const sortedBandNumbers = (bands: Band[]) => bands
-          .map(band => band.bandNumber)
-          .sort((a, b) => a - b);
-        this.scenarioService.save({...this.scenario,
-          ecosystemsToInclude: sortedBandNumbers(selectedComponents.ecoComponent),
-          pressuresToInclude: sortedBandNumbers(selectedComponents.pressureComponent)}).pipe(
-          take(1))
-          .subscribe(() => {
-              this.calcService.calculate(this.scenario);
-            }
-          );
-      });
+    this.store.dispatch(ScenarioActions.saveAndCalculateActiveScenario());
   }
 
   onCheckRarityIndicesDomain(domain: string) {
@@ -301,7 +286,7 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
 
   save() {
     this.unsaved = false;
-    this.store.dispatch(ScenarioActions.saveActiveScenario({ scenarioToBeSaved: this.scenario }));
+    this.store.dispatch(ScenarioActions.saveActiveScenario());
   }
 
   deleteChange = async (bandTypeString: string, bandNumber: number, bandName: string) => {

--- a/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-detail/scenario-detail.component.ts
@@ -352,9 +352,9 @@ export class ScenarioDetailComponent implements OnInit, OnDestroy {
     if(operation === CalcOperation.RarityAdjusted) {
       const normalizationOptions = this.getNormalizationOptions();
       this.store.dispatch(ScenarioActions.changeScenarioOperationParams({operationParams: this.getParams() ? this.getParams() : {'domain': 'GLOBAL'}}));
-      if(normalizationOptions.type === NormalizationType.Domain) {
+      if(normalizationOptions.type === NormalizationType.DOMAIN) {
         this.store.dispatch(ScenarioActions.changeScenarioNormalization(
-          { normalizationOptions: {...normalizationOptions, type: NormalizationType.Area } }
+          { normalizationOptions: {...normalizationOptions, type: NormalizationType.AREA } }
         ));
       }
     }

--- a/frontend/src/app/map-view/scenario/scenario-editor.component.ts
+++ b/frontend/src/app/map-view/scenario/scenario-editor.component.ts
@@ -32,10 +32,10 @@ export class ScenarioEditorComponent {
     this.store.dispatch(ScenarioActions.fetchScenarios());
     this.store.select(ScenarioSelectors.selectActiveScenario)
       .subscribe(scenario => {
-        this.activeScenario = scenario;
-        if(scenario) {
+        if(scenario && scenario.id !== this.activeScenario?.id) {
           this.store.dispatch(MetadataActions.fetchMetadata());
         }
+        this.activeScenario = scenario;
       });
     this.store.select(ScenarioSelectors.selectActiveScenarioArea)
       .subscribe(areaIndex => this.activeAreaIndex = areaIndex);

--- a/frontend/src/app/report/calculation-report.component.ts
+++ b/frontend/src/app/report/calculation-report.component.ts
@@ -52,7 +52,7 @@ export class CalculationReportComponent extends AbstractReport {
               that.store.dispatch(MetadataActions.fetchMetadataForBaseline({baselineName: report.baselineName}));
               window.parent.postMessage({type: 'calcReportLoaded', calcId: +calcId!}, window.origin);
               that.areaDict = reportService.setAreaDict(report);
-              that.isDomainNormalization = report.normalization.type === NormalizationType.Domain;
+              that.isDomainNormalization = report.normalization.type === NormalizationType.DOMAIN;
             },
             error() {
               that.loadingReport = false;

--- a/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.html
+++ b/frontend/src/app/report/cumulative-effect-etc/cumulative-effect-etc.component.html
@@ -16,18 +16,18 @@
     <tr *ngIf="normalization">
       <th>{{ 'report.cumulative-effect-etc.normalization.title' | translate }}:</th>
       <td [ngSwitch]="normalization.type">
-        <ng-container *ngSwitchCase="type.Domain">
+        <ng-container *ngSwitchCase="type.DOMAIN">
           {{ 'report.cumulative-effect-etc.normalization.domain' | translate:{ ordinalPercentileValue: this.percentileValue | ordinal:locale } }}<sup>*</sup>
         </ng-container>
-        <ng-container *ngSwitchCase="type.Area">
+        <ng-container *ngSwitchCase="type.AREA">
           {{ 'report.cumulative-effect-etc.normalization.area' | translate }}
         </ng-container>
-        <ng-container *ngSwitchCase="type.StandardDeviation">
+        <ng-container *ngSwitchCase="type.STANDARD_DEVIATION">
           {{ 'report.cumulative-effect-etc.normalization.mean-plus-stddev' | translate:
           { stddevMultiplier: jsMath.abs(normalization.stdDevMultiplier),
             positiveOrNegative: normalization.stdDevMultiplier > 0 ? '+' : '-' } }}
         </ng-container>
-        <ng-container *ngSwitchCase="type.UserDefined">
+        <ng-container *ngSwitchCase="type.USER_DEFINED">
           {{ 'report.cumulative-effect-etc.normalization.custom' | translate }} = {{
           normalization.userDefinedValue | number: '1.0-4':locale }}
         </ng-container>

--- a/frontend/src/app/report/histogram/histogram.component.spec.ts
+++ b/frontend/src/app/report/histogram/histogram.component.spec.ts
@@ -40,7 +40,7 @@ describe('HistogramComponent', () => {
       max: 100,
       min: 0,
       name: "",
-      normalization: {type: NormalizationType.Domain},
+      normalization: {type: NormalizationType.DOMAIN},
       operationName: "",
       operationOptions: {},
       scenarioChanges: {baseChanges: {}, areaChanges: {}},

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -188,7 +188,7 @@
                 "description": "Set maximum value based on",
                 "area": "Maximum value in computed area",
                 "domain": "{{ ordinalPercentileValue }} percentile in MSP area",
-                "mean-plus-stddev": "Mean +/- multiple of \nstandard deviation:",
+                "mean-plus-stddev": "Mean + multiple of \nstandard deviation:",
                 "custom": "User-defined value:",
                 "custom-value": "Value"
             },

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -188,7 +188,7 @@
                 "description": "Définir la valeur maximale en tant que:",
                 "area": "Valeur maximale dans la zone de calcul",
                 "domain": "Normalisé au {{ ordinalPercentileValue }} centile dans la zone MSP",
-                "mean-plus-stddev": "Moyenne +/- \nmultiple de l'écart type:",
+                "mean-plus-stddev": "Moyenne + \nmultiple de l'écart type:",
                 "custom": "Valeur définie par l'utilisateur:",
                 "custom-value": "Valeur"
             },

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -188,7 +188,7 @@
                 "description": "Sätt maximalt värde baserat på",
                 "area": "Maximalt värde i valt område",
                 "domain": "{{ ordinalPercentileValue }} percentil i havsplaneområde",
-                "mean-plus-stddev": "Medelvärde +/- multipel av \nstandardavvikelsen:",
+                "mean-plus-stddev": "Medelvärde + multipel av \nstandardavvikelsen:",
                 "custom": "Egendefinierat värde",
                 "custom-value": "Värde"
             },

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/MetaDataService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/MetaDataService.java
@@ -23,13 +23,34 @@ public class MetaDataService {
     @EJB
     BaselineVersionService baselineVersionService;
 
-    public MetadataDto findMetadata(String baselineName, String preferredLanguage) throws SymphonyStandardAppException {
+    public final static String fullMetaQuery = "SELECT m FROM Metadata m " +
+            "WHERE m.band IN :bandsList " +
+            "AND (m.language = :language " +
+            "OR (m.language = m.band.baseline.locale " +
+            "AND m.metaField NOT IN " +
+            "(SELECT m2.metaField FROM Metadata m2 " +
+            "WHERE m2.band IN :bandsList " +
+            "AND m2.language = :language)))";
+
+    public final static String sparseMetaQuery = "SELECT m FROM Metadata m " +
+            "WHERE m.band IN :bandsList " +
+            "AND (m.language = :language " +
+            "OR (m.language = m.band.baseline.locale " +
+            "AND m.metaField IN ('title', 'symphonytheme')" +
+            "AND m.metaField NOT IN " +
+            "(SELECT m2.metaField FROM Metadata m2 " +
+            "WHERE m2.band IN :bandsList " +
+            "AND m2.metaField IN ('title', 'symphonytheme')" +
+            "AND m2.language = :language)))";
+
+    public MetadataDto findMetadata(String baselineName, String preferredLanguage, boolean sparse) throws SymphonyStandardAppException {
         BaselineVersion baseline = baselineVersionService.getVersionByName(baselineName);
         MetadataDto metadataDto = new MetadataDto();
-        metadataDto.setEcoComponent(getComponentDto("Ecosystem", baseline.getId(), preferredLanguage));
-        metadataDto.setPressureComponent(getComponentDto("Pressure", baseline.getId(), preferredLanguage));
+        metadataDto.setEcoComponent(getComponentDto("Ecosystem", baseline.getId(), preferredLanguage, sparse));
+        metadataDto.setPressureComponent(getComponentDto("Pressure", baseline.getId(), preferredLanguage, sparse));
         metadataDto.setLanguage(preferredLanguage);
         return metadataDto;
+
     }
 
     public Map<Integer, String>
@@ -58,7 +79,7 @@ public class MetaDataService {
             .collect(HashMap::new, (m, t) -> m.put(t.get(0, Integer.class), t.get(1, String.class)), HashMap::putAll);
     }
 
-    public MetadataComponentDto getComponentDto(String componentName, int baselineVersionId, String language) {
+    public MetadataComponentDto getComponentDto(String componentName, int baselineVersionId, String language, boolean sparse) {
         MetadataComponentDto componentDto = new MetadataComponentDto();
 
         List<SymphonyBand> bandsList = getBandsForBaselineComponent(componentName, baselineVersionId);
@@ -66,14 +87,7 @@ public class MetaDataService {
         // Select all Metadata for the given SymphonyBands and the given language.
         // If a translation for a field is not found, fall back to baseline default language.
         List<Metadata> metadataList =
-            em.createQuery("SELECT m FROM Metadata m " +
-                              "WHERE m.band IN :bandsList " +
-                                "AND (m.language = :language " +
-                                    "OR (m.language = m.band.baseline.locale " +
-                                        "AND m.metaField NOT IN " +
-                                            "(SELECT m2.metaField FROM Metadata m2 " +
-                                                "WHERE m2.band IN :bandsList " +
-                                                "AND m2.language = :language)))")
+                em.createQuery(sparse ? sparseMetaQuery : fullMetaQuery, Metadata.class)
                 .setParameter("bandsList", bandsList)
                 .setParameter("language", language)
                 .getResultList();
@@ -109,7 +123,7 @@ public class MetaDataService {
         return em.createQuery(
             "SELECT b FROM SymphonyBand b " +
                 "WHERE b.baseline.id = :baselineVersionId " +
-                "AND b.category = :category")
+                "AND b.category = :category", SymphonyBand.class)
             .setParameter("baselineVersionId", baselineVersionId)
             .setParameter("category", componentName)
             .getResultList();

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/ReportService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/ReportService.java
@@ -314,7 +314,7 @@ public class ReportService {
     static final String rptRowFormat = "%s" + CSV_FIELD_SEPARATOR + "%.2f%%";
 
     public String generateCSVReport(CalculationResult calc, Locale locale) throws SymphonyStandardAppException {
-        var metadata = metaDataService.findMetadata(calc.getBaselineVersion().getName(), locale.getLanguage());
+        var metadata = metaDataService.findMetadata(calc.getBaselineVersion().getName(), locale.getLanguage(), true);
         var ecocomponentMetadata = flattenAndSort(metadata.getEcoComponent());
         var pressureMetadata = flattenAndSort(metadata.getPressureComponent());
 
@@ -371,7 +371,7 @@ public class ReportService {
     static final String cmpRowFormat = "%s" + CSV_FIELD_SEPARATOR + "%.2f" + CSV_FIELD_SEPARATOR + "%.2f" + CSV_FIELD_SEPARATOR + "%.2f%%";
 
     public String generateCSVComparisonReport(CalculationResult calcA, CalculationResult calcB, Locale locale) throws SymphonyStandardAppException {
-        MetadataDto metadata = metaDataService.findMetadata(calcA.getBaselineVersion().getName(), locale.getLanguage());
+        MetadataDto metadata = metaDataService.findMetadata(calcA.getBaselineVersion().getName(), locale.getLanguage(), true);
         SymphonyBandDto[]   ecocomponentMetadata = flattenAndSort(metadata.getEcoComponent()),
                                 pressureMetadata = flattenAndSort(metadata.getPressureComponent());
 

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/CalculationREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/CalculationREST.java
@@ -272,7 +272,7 @@ public class CalculationREST {
         MathTransform clientTransform =
             CRS.findMathTransform(coverage.getGridGeometry().getCoordinateReferenceSystem(), clientCRS);
 
-        NormalizationType  = this.scenario.getNormalization().type;
+        NormalizationType normalizationType = this.scenario.getNormalization().type;
         RasterNormalizer normalizer = normalizationFactory.getNormalizer(normalizationType);
 
         int[] areas = scenario.getAreaMatrixMap().keySet().stream().sorted().mapToInt(i -> i).toArray();

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/MetaDataREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/MetaDataREST.java
@@ -42,7 +42,7 @@ public class MetaDataREST {
         MetadataDto metaData = metaDataService.findMetadata(baselineName,
                 preferredLanguage.isEmpty() ?
                     props.getProperty("meta.default_language") :
-                    preferredLanguage );
+                    preferredLanguage, activeScenarioId > 0);
 
         if(activeScenarioId > 0) {
             int[] ecosystemIds, pressureIds;

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/ScenarioREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/ScenarioREST.java
@@ -102,6 +102,17 @@ public class ScenarioREST {
         } else throw new NotAuthorizedException("Not owner of scenario");
     }
 
+    @GET
+    @ApiOperation(value = "Get scenario by id", response = ScenarioDto.class)
+    @Path("{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed("GRP_SYMPHONY")
+    public ScenarioDto findById(@Context HttpServletRequest req, @PathParam("id") int id) {
+        Scenario scenario = service.findById(id);
+        checkAndAuthorizeScenarioOwner(req, scenario);
+        return new ScenarioDto(scenario);
+    }
+
     // Unused endpoint at the moment.
     // Might be useful for future functionality.
     @PUT

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/service/CalculationAreaServiceTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/service/CalculationAreaServiceTest.java
@@ -1,6 +1,7 @@
 package se.havochvatten.symphony.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.internal.RestAssuredResponseOptionsImpl;
 import org.geotools.geojson.geom.GeometryJSON;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +17,7 @@ import se.havochvatten.symphony.entity.Scenario;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
@@ -163,13 +165,13 @@ public class CalculationAreaServiceTest {
 
         List<SymphonyBand> ecoBands = getMockedEcoBands(pressureBands, sensitivityMatrix);
 
-        Query mockedPressuresQuery = mock(Query.class),
-              mockedEcoQuery = mock(Query.class);
+        TypedQuery mockedPressuresQuery = mock(TypedQuery.class),
+              mockedEcoQuery = mock(TypedQuery.class);
 
         when(calculationAreaService.metadataService.em.createQuery(
             "SELECT b FROM SymphonyBand b " +
             "WHERE b.baseline.id = :baselineVersionId " +
-            "AND b.category = :category")).thenReturn(mockedPressuresQuery, mockedEcoQuery);
+            "AND b.category = :category", SymphonyBand.class)).thenReturn(mockedPressuresQuery, mockedEcoQuery);
 
         when(mockedPressuresQuery.setParameter(anyString(), anyObject())).thenReturn(mockedPressuresQuery);
         when(mockedPressuresQuery.setParameter("baselineVersionId", 1)).thenReturn(mockedPressuresQuery);

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/service/CalculationAreaServiceTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/service/CalculationAreaServiceTest.java
@@ -1,7 +1,6 @@
 package se.havochvatten.symphony.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.restassured.internal.RestAssuredResponseOptionsImpl;
 import org.geotools.geojson.geom.GeometryJSON;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,7 +15,6 @@ import se.havochvatten.symphony.exception.SymphonyStandardAppException;
 import se.havochvatten.symphony.entity.Scenario;
 
 import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import java.io.IOException;
 import java.math.BigDecimal;


### PR DESCRIPTION
Options for other normalization settings than area and msp-max have been broken.
The problem has a few different parts, both front- and back end. This branch should fix the issue.

Included as well is a sparse alternative for fetching metadata in scenario "mode", a sanitary amendment preventing unnecessary data transfers every time the scenario is persisted in the UI.

Thank you @hammarlinus for reporting this bug to us!