### PR TITLE
SYM-669: 'Combined' data sheet

### DIFF
--- a/frontend/src/app/data/calculation/calculation.interfaces.ts
+++ b/frontend/src/app/data/calculation/calculation.interfaces.ts
@@ -145,6 +145,7 @@ export interface CompoundComparison extends CompoundComparisonSlice {
 export interface DownloadCompoundComparisonOptions {
   asJson: boolean;
   includeUnchanged: boolean;
+  includeCombined: boolean;
 }
 
 export interface OperationParams {

--- a/frontend/src/app/map-view/compound-comparison-list-dialog/compound-comparison-list-dialog.component.html
+++ b/frontend/src/app/map-view/compound-comparison-list-dialog/compound-comparison-list-dialog.component.html
@@ -23,7 +23,7 @@
       ></span>
     </div>
     <div class="list-actions">
-      <app-icon iconType="save" [title]="'map.compound-data-list.download' | translate"
+      <app-icon iconType="save" [title]="'map.compound-data-list.download.header' | translate"
                 (click)="downloadCC(cmp); $event.stopPropagation()">
       </app-icon>
       <app-icon iconType="delete" [title]="'map.compound-data-list.delete' | translate"

--- a/frontend/src/app/map-view/compound-comparison-list-dialog/compound-comparison-list-dialog.component.ts
+++ b/frontend/src/app/map-view/compound-comparison-list-dialog/compound-comparison-list-dialog.component.ts
@@ -68,7 +68,8 @@ export class CompoundComparisonListDialogComponent extends Listable {
     if(ccDownloadOptions) {
       const params = new URLSearchParams({
         lang: this.translateService.currentLang,
-        nonzero: !ccDownloadOptions.includeUnchanged + ''
+        nonzero: !ccDownloadOptions.includeUnchanged + '',
+        combined: ccDownloadOptions.includeCombined + ''
       });
 
       if (!ccDownloadOptions.asJson) {
@@ -92,8 +93,9 @@ export class CompoundComparisonListDialogComponent extends Listable {
       'report.cumulative-effect-etc.max',
       'map.compound-data-list.terms.total', 'map.compound-data-list.terms.sum', 'map.compound-data-list.terms.baseline',
       'map.compound-data-list.terms.difference', 'map.compound-data-list.compound-comparison-data',
-      'map.compound-data-list.terms.pixels', 'map.compound-data-list.terms.non-planar',
-      'map.metadata.ecosystem', 'map.metadata.pressure']
+      'map.compound-data-list.terms.pixels', 'map.compound-data-list.terms.non-planar', 'map.compound-data-list.terms.combined',
+      'map.compound-data-list.terms.scenarioTitle', 'map.compound-data-list.terms.scenario',
+      'map.metadata.theme', 'map.metadata.ecosystem', 'map.metadata.pressure']
       );
 
     return JSON.stringify({
@@ -108,6 +110,10 @@ export class CompoundComparisonListDialogComponent extends Listable {
       max: titles['report.cumulative-effect-etc.max'],
       pixels: titles['map.compound-data-list.terms.pixels'],
       nonPlanar: titles['map.compound-data-list.terms.non-planar'],
+      combined: titles['map.compound-data-list.terms.combined'],
+      scenarioTitle: titles['map.compound-data-list.terms.scenarioTitle'],
+      scenario: titles['map.compound-data-list.terms.scenario'],
+      theme: titles['map.metadata.theme'],
       ecosystem: titleCase(titles['map.metadata.ecosystem']),
       pressure: titleCase(titles['map.metadata.pressure'])
     });

--- a/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.html
+++ b/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.html
@@ -1,4 +1,4 @@
-<h3>{{ 'map.compound-data-list.download.title' | translate }}</h3>
+<h3>{{ 'map.compound-data-list.download.header' | translate }}</h3>
 <p>
   <em>“{{ comparisonName }}”</em>
 </p>

--- a/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.html
+++ b/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.html
@@ -1,29 +1,34 @@
-<h3>{{ 'map.compound-data-list.download' | translate }}</h3>
+<h3>{{ 'map.compound-data-list.download.title' | translate }}</h3>
 <p>
   <em>“{{ comparisonName }}”</em>
 </p>
 <div class="format-options">
-  <label for="format" class="format-label">{{ 'map.compound-data-list.download-select-format' | translate }}</label>
-  <mat-radio-group (change)="setFormat($event)" name="format">
+  <label for="format" class="format-label">{{ 'map.compound-data-list.download.select-format' | translate }}</label>
+  <mat-radio-group (change)="setFormat($event)" name="format" id="format">
     <mat-radio-button value="json" checked>{{
-        'map.compound-data-list.download-format.json' | translate
+        'map.compound-data-list.download.format.json' | translate
       }}</mat-radio-button>
     <mat-radio-button value="ods">{{
-        'map.compound-data-list.download-format.ods' | translate
+        'map.compound-data-list.download.format.ods' | translate
       }}</mat-radio-button>
   </mat-radio-group>
-  <div class="include-unchanged">
-    <label>
-      <mat-checkbox [(ngModel)]="downloadOptions.includeUnchanged">{{
-          'map.compound-data-list.download-include-unchanged' | translate
+  <div class="include-options">
+    <label for="inc-unchanged">
+      <mat-checkbox id="inc-unchanged" [(ngModel)]="downloadOptions.includeUnchanged">{{
+          'map.compound-data-list.download.include-unchanged' | translate
       }}</mat-checkbox>
+    </label>
+    <label for="inc-combined">
+      <mat-checkbox id="inc-combined" [(ngModel)]="downloadOptions.includeCombined" [disabled]="downloadOptions.asJson">{{
+          'map.compound-data-list.download.include-combined-dataset' | translate
+        }}</mat-checkbox>
     </label>
   </div>
 </div>
 <div class="button-pane">
   <button mat-flat-button
           (click)="download()">{{
-      'map.compound-data-list.confirm-download' | translate
+      'map.compound-data-list.download.confirm' | translate
     }}</button>
   <button mat-flat-button [ngClass]="'secondary'"
           (click)="close()">{{

--- a/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.scss
+++ b/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.scss
@@ -36,12 +36,13 @@
       }
     }
 
-    .include-unchanged {
+    .include-options {
       padding-left: 1rem;
 
       label {
         font-size: 1.3rem;
         line-height: 2rem;
+        margin-right: 1.6rem;
       }
     }
   }

--- a/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.ts
+++ b/frontend/src/app/map-view/compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component.ts
@@ -14,7 +14,8 @@ export class DownloadCompoundComparisonDialogComponent {
   comparisonName = '';
   downloadOptions: DownloadCompoundComparisonOptions = {
     asJson: true,
-    includeUnchanged: true
+    includeUnchanged: true,
+    includeCombined: false
   };
 
   constructor(private dialog: DialogRef,
@@ -32,5 +33,8 @@ export class DownloadCompoundComparisonDialogComponent {
 
   setFormat(changeEvent: MatRadioChange) {
     this.downloadOptions.asJson = changeEvent.value === 'json';
+    if (this.downloadOptions.asJson) {
+      this.downloadOptions.includeCombined = false;
+    }
   }
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -305,6 +305,7 @@
             "label": "Show metadata",
             "header": "Metadata regarding {{ layerType }}: {{ layerName }}",
             "close": "Close",
+            "theme": "theme",
             "ecosystem": "ecosystem",
             "pressure": "pressure",
             "no-info": "Metadatum missing.",
@@ -523,14 +524,17 @@
             "calculation-basis-info": "The comparative values are based on the following calculations",
             "more": "more",
             "delete": "Delete compound comparison",
-            "download": "Download compound comparison",
-            "download-select-format": "Select format to download",
-            "download-format": {
-                "json": "As data (JSON)",
-                "ods": "As spreadsheet (ODS)"
+            "download": {
+                "header": "Download compound comparison",
+                "select-format": "Select format to download",
+                "format": {
+                    "json": "As data (JSON)",
+                    "ods": "As spreadsheet (ODS)"
+                },
+                "include-unchanged": "Include unchanged results",
+                "include-combined-dataset": "Include combined dataset",
+                "confirm": "Download"
             },
-            "download-include-unchanged": "Include unchanged results",
-            "confirm-download": "Download",
             "filter-hint": "Filter list item by name",
             "delete-modal": {
                 "header": "Delete compound comparison",
@@ -542,7 +546,10 @@
                 "baseline": "Baseline",
                 "difference": "Difference",
                 "pixels": "Number of pixels",
-                "non-planar": "Non-planar projection"
+                "non-planar": "Non-planar projection",
+                "scenarioTitle": "Scenario title",
+                "scenario": "Scenario",
+                "combined": "Combined dataset"
             }
         },
         "area-options": {

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -305,6 +305,7 @@
             "label": "Voir les métadonnées",
             "header": "Métadonnées concernant {{ layerType }}: {{ layerName }}",
             "close": "Fermer",
+            "theme": "groupe",
             "ecosystem": "écosystème",
             "pressure": "pression",
             "no-info": "Métadonnée manquante.",
@@ -523,14 +524,17 @@
             "calculation-basis-info": "La comparaison des valeurs est basée sur les calculs suivants",
             "more": "de plus",
             "delete": "Supprimer ca comparaison composée",
-            "download": "Télécharger la comparaison composée",
-            "download-select-format": "Choisissez le format de téléchargement",
-            "download-format": {
-                "json": "En tant que données (JSON)",
-                "ods": "En tant que feuille de calcul (ODS)"
+            "download": {
+                "header": "Télécharger la comparaison composée",
+                "select-format": "Choisissez le format de téléchargement",
+                "format": {
+                    "json": "En tant que données (JSON)",
+                    "ods": "En tant que feuille de calcul (ODS)"
+                },
+                "include-unchanged": "Inclure les valeurs inchangées",
+                "include-combined-dataset": "Inclure des données combinées",
+                "confirm": "Télécharger"
             },
-            "download-include-unchanged": "Inclure les valeurs inchangées",
-            "confirm-download": "Télécharger",
             "filter-hint": "Filtrer la liste par nom",
             "delete-modal": {
                 "header": "Supprimer la comparaison composée",
@@ -542,7 +546,10 @@
                 "baseline": "Reférence",
                 "difference": "Différence",
                 "pixels": "Nombre de pixels",
-                "non-planar": "Projection non planaire"
+                "non-planar": "Projection non planaire",
+                "scenarioTitle": "Nom du scénario",
+                "scenario": "Scénario",
+                "combined": "Données combinées"
             }
         },
         "area-options": {

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -305,6 +305,7 @@
             "label": "Visa metadata",
             "header": "Metadata avseende {{ layerType }}: {{ layerName }}",
             "close": "Stäng",
+            "theme": "grupp",
             "ecosystem": "naturvärde",
             "pressure": "belastning",
             "no-info": "Uppgift saknas.",
@@ -523,14 +524,17 @@
             "calculation-basis-info": "Jämförelsevärdena baserar sig på följande beräkningar",
             "more": "till",
             "delete": "Radera sammanslagen jämförelse",
-            "download": "Spara ned sammanslagen jämförelse",
-            "download-select-format": "Välj format att ladda ned",
-            "download-format": {
-                "json": "Som data (JSON)",
-                "ods": "Som kalkylblad (ODS)"
+            "download": {
+                "header": "Spara ned sammanslagen jämförelse",
+                "select-format": "Välj format att ladda ned",
+                "format": {
+                    "json": "Som data (JSON)",
+                    "ods": "Som kalkylblad (ODS)"
+                },
+                "include-unchanged": "Inkludera oförändrade förekomster",
+                "include-combined-dataset": "Inkludera kombinerad data",
+                "confirm": "Ladda ned"
             },
-            "download-include-unchanged": "Inkludera oförändrade förekomster",
-            "confirm-download": "Ladda ned",
             "filter-hint": "Filtrera listan per namn",
             "delete-modal": {
                 "header": "Radera sammanslagen jämförelse",
@@ -542,7 +546,10 @@
                 "baseline": "Baseline",
                 "difference": "Differens",
                 "pixels": "Antal pixlar",
-                "non-planar": "Icke-plan projektion"
+                "non-planar": "Icke-plan projektion",
+                "scenarioTitle": "Scenarionamn",
+                "scenario": "Scenario",
+                "combined": "Kombinerad data"
             }
         },
         "area-options": {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/MetaDataService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/MetaDataService.java
@@ -43,37 +43,37 @@ public class MetaDataService {
             "AND m2.metaField IN ('title', 'symphonytheme')" +
             "AND m2.language = :language)))";
 
-    public MetadataDto findMetadata(String baselineName, String preferredLanguage, boolean sparse) throws SymphonyStandardAppException {
+    public MetadataDto findMetadata
+        (String baselineName, String preferredLanguage, boolean sparse) throws SymphonyStandardAppException {
         BaselineVersion baseline = baselineVersionService.getVersionByName(baselineName);
         MetadataDto metadataDto = new MetadataDto();
         metadataDto.setEcoComponent(getComponentDto("Ecosystem", baseline.getId(), preferredLanguage, sparse));
         metadataDto.setPressureComponent(getComponentDto("Pressure", baseline.getId(), preferredLanguage, sparse));
         metadataDto.setLanguage(preferredLanguage);
         return metadataDto;
-
     }
 
-    public Map<Integer, String>
-        getComponentTitles(int baselineVersionId, LayerType category, String preferredLanguage)
-        throws SymphonyStandardAppException {
+    public Map<Integer, String> getSingleMetaFieldForComponent
+        (int baselineVersionId, LayerType category, String field, String preferredLanguage) {
 
         TypedQuery<Tuple> bandTitlesQuery = em.createQuery(
             "SELECT m.band.bandnumber, m.metaValue FROM Metadata m " +
                     "WHERE m.band.baseline.id = :baselineVersionId " +
-                    "AND m.metaField = 'title' " +
+                    "AND m.metaField = :field " +
                     "AND m.band.category = :category " +
                     "AND (m.language = :language " +
                         "OR (m.language = m.band.baseline.locale " +
                         "AND m.metaField NOT IN " +
                             "(SELECT m2.metaField FROM Metadata m2 " +
                             "WHERE m2.band.baseline.id = :baselineVersionId " +
-                            "AND m2.metaField = 'title' " +
+                            "AND m2.metaField = :field " +
                             "AND m2.language = :language)))" +
                     "ORDER BY m.band.bandnumber", Tuple.class);
 
         return bandTitlesQuery
             .setParameter("baselineVersionId", baselineVersionId)
             .setParameter("category", category == LayerType.ECOSYSTEM ? "Ecosystem" : "Pressure")
+            .setParameter("field", field)
             .setParameter("language", preferredLanguage)
             .getResultStream()
             .collect(HashMap::new, (m, t) -> m.put(t.get(0, Integer.class), t.get(1, String.class)), HashMap::putAll);

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/MetaDataService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/MetaDataService.java
@@ -56,7 +56,7 @@ public class MetaDataService {
     public Map<Integer, String> getSingleMetaFieldForComponent
         (int baselineVersionId, LayerType category, String field, String preferredLanguage) {
 
-        TypedQuery<Tuple> bandTitlesQuery = em.createQuery(
+        TypedQuery<Tuple> singleMetaFieldQuery = em.createQuery(
             "SELECT m.band.bandnumber, m.metaValue FROM Metadata m " +
                     "WHERE m.band.baseline.id = :baselineVersionId " +
                     "AND m.metaField = :field " +
@@ -70,7 +70,7 @@ public class MetaDataService {
                             "AND m2.language = :language)))" +
                     "ORDER BY m.band.bandnumber", Tuple.class);
 
-        return bandTitlesQuery
+        return singleMetaFieldQuery
             .setParameter("baselineVersionId", baselineVersionId)
             .setParameter("category", category == LayerType.ECOSYSTEM ? "Ecosystem" : "Pressure")
             .setParameter("field", field)

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/util/ODSStyles.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/util/ODSStyles.java
@@ -11,7 +11,8 @@ public class ODSStyles {
         ecoHeader = new Style(), pressureHeaderLeft  = new Style(), pressureHeaderRight  = new Style(),
         onlyBold = new Style(), valueStyle = new Style(), thickRightBorder = new Style(), resultSep = new Style(),
         totalE = new Style(), totalE2 = new Style(), totalP = new Style(), totalP2 = new Style(),
-        totalHE = new Style(), totalHP = new Style(), totalC = new Style(), totalC2 = new Style();
+        totalHE = new Style(), totalHP = new Style(), totalC = new Style(), totalC2 = new Style(),
+        comboHeader = new Style(), comboValue = new Style(), comboTheme = new Style();
 
     static {
         cmpName.setFontSize(14);
@@ -23,12 +24,15 @@ public class ODSStyles {
         for (Style s : new Style[]
             { ecoHeader, pressureHeaderLeft, pressureHeaderRight, valueStyle,
                 totalHeaderLeft, totalHeaderRight, totalSubHeader,
-                totalE, totalP, totalHE, totalHP, totalC, totalC2, onlyBold }) {
+                totalE, totalP, totalHE, totalHP, totalC, totalC2, onlyBold,
+                comboHeader, comboValue }) {
             s.setFontSize(10);
         }
 
+        comboTheme.setFontSize(9);
+
         for(Style s: new Style[]
-            { onlyBold, totalSubHeader, totalHE, totalHP, totalC, totalC2, calcName }) {
+            { onlyBold, totalSubHeader, totalHE, totalHP, totalC, totalC2, calcName, comboHeader }) {
             s.setBold(true);
         }
 
@@ -171,5 +175,26 @@ public class ODSStyles {
                 false, null,
                 false, null,
                 false, null));
+
+        comboValue.setBorders(
+            new Borders(
+                true, "thin solid #000000",
+                true, "thin solid #000000",
+                true, "thin solid #000000",
+                true, "thin solid #000000"));
+
+        comboTheme.setBorders(
+            new Borders(
+                true, "thin solid #000000",
+                true, "thin solid #000000",
+                true, "thin solid #000000",
+                true, "thin solid #000000"));
+
+        comboHeader.setBorders(
+            new Borders(
+                false, null,
+                true, "thin solid #000000",
+                true, "thin solid #000000",
+                true, "thin solid #000000"));
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/ReportREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/ReportREST.java
@@ -285,6 +285,7 @@ public class ReportREST {
                                              @PathParam("id") Integer id,
                                              @PathParam("format") String format,
                                              @DefaultValue("false") @QueryParam("nonzero") boolean excludeZeroes,
+                                             @DefaultValue("false") @QueryParam("combined") boolean includeCombinedSheet,
                                              @DefaultValue("") @QueryParam("meta-terms") String metatermsParam,
                                              @DefaultValue("en") @QueryParam("lang") String preferredLanguage) {
 
@@ -302,7 +303,9 @@ public class ReportREST {
                     return ok(reportService.generateMultiComparisonAsJSON(cmp, preferredLanguage, excludeZeroes)).
                         header("Content-Disposition", attachmentHeader).build();
                 else {
-                    byte[] ods = reportService.generateMultiComparisonAsODS(cmp, preferredLanguage, excludeZeroes, metaTerms);
+                    byte[] ods =
+                        reportService.generateMultiComparisonAsODS(cmp, preferredLanguage,
+                                                                   excludeZeroes, includeCombinedSheet, metaTerms);
                     return ok(ods).
                         header("Content-Disposition",attachmentHeader).build();
                 }


### PR DESCRIPTION
Introduces an option to include a "combined" data sheet in the spreadsheet format export feature for compound comparison calculations (#147)
The term "combined" is used here in the sense that all _(Pressure x Ecosystem)_ values for every included comparison result are 'combined' with metadata themes and titles into a single table.
_Example._
![image](https://github.com/havochvatten/MSP-Symphony/assets/112889179/5b2cd85d-6086-4d86-bd87-966516b3e2c3)

The feature aims specifically to facilitate the utilization of "pivoting" and "auto-filtering" functionality that is commonly available in spreadsheet software (e.g LibreOffice Calc, MS Excel). 