### PR TITLE
Patch 1.22.1 (PR for team review)

### DIFF
--- a/frontend/src/build-info.ts
+++ b/frontend/src/build-info.ts
@@ -1,6 +1,6 @@
 // This file should be updated by CI system with actual build information
 export default {
-  version: '1.22.0',
+  version: '1.22.1',
   buildNumber: '<unknown>',
-  gitSha: 'a994f05' // Deeplink to source repo?
+  gitSha: '2eadc6d' // Deeplink to source repo?
 };

--- a/symphony-ws/pom.xml
+++ b/symphony-ws/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>se.havochvatten.symphony</groupId>
     <artifactId>symphony-ws</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <packaging>war</packaging>
 
     <name>Symphony webservices</name>

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/CalculationAreaService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/CalculationAreaService.java
@@ -402,9 +402,11 @@ public class CalculationAreaService {
         }
 
         List<SymphonyBand> pressuresList =
-            metadataService.getBandsForBaselineComponent("Pressure", baseDataVersionId, true);
+            metadataService.getBandsForBaselineComponent("Pressure", baseDataVersionId, true)
+                .stream().sorted(Comparator.comparingInt(SymphonyBand::getBandNumber)).toList();
         List<SymphonyBand> ecosystemsList =
-            metadataService.getBandsForBaselineComponent("Ecosystem", baseDataVersionId, true);
+            metadataService.getBandsForBaselineComponent("Ecosystem", baseDataVersionId, true)
+                .stream().sorted(Comparator.comparingInt(SymphonyBand::getBandNumber)).toList();
 
         double[][] matrix = new double[pressuresList.size()][ecosystemsList.size()];
 


### PR DESCRIPTION
Unless the default order of bands, when read from the db, coincides with the band numbering (sequential position) in the raster stack - the scores for all sensitivity matrices will become 'jumbled up'.

This is a serious bug that warrants a patch release.
Putting this as a PR to review, the merge is directed directly to main (and afterward we'll sync the cherry-picked commit into develop).