### PR TITLE
SYM-692: Omit excluded components in report sheet

### DIFF
--- a/frontend/src/app/report/impact-table/impact-table.component.html
+++ b/frontend/src/app/report/impact-table/impact-table.component.html
@@ -1,29 +1,28 @@
 <h4>{{ title }}</h4>
-<table *ngFor="let group of bandGroups; first as isFirstGroup">
-  <tr class="title-row">
-    <th>{{ group.symphonyThemeName }}</th>
-    <ng-container *ngIf="true">
-      <th *ngFor="let name of names">{{ name }}</th>
-    </ng-container>
-  </tr>
-  <tr *ngFor="let band of group.bands"
-      [ngClass]="{
-        'excluded' : isExcluded(band.bandNumber)
-      }"
-  >
-    <td class="band-name">
-      {{ band.displayName }}
-      <span class="line"></span>
-    </td>
-    <td class="impact" *ngFor="let impact of scenarioImpacts; last as percentageColumn">
-      <ng-container *ngIf="!isExcluded(band.bandNumber)">
-        <ng-container *ngIf="percentageColumn; else totalsColumn">
-          {{ formatPercentage(impact[band.bandNumber], 'report.common.not-measurable' | translate, scenarioImpacts.length > 2) }}
-        </ng-container>
-        <ng-template #totalsColumn>
-          {{ impact[band.bandNumber] | number:'1.0-0':locale }}
-        </ng-template>
+<ng-container *ngFor="let group of bandGroups">
+  <table *ngIf="!groupExcluded(group)">
+    <tr class="title-row">
+      <th>{{ group.symphonyThemeName }}</th>
+      <ng-container *ngIf="true">
+        <th *ngFor="let name of names">{{ name }}</th>
       </ng-container>
-    </td>
-  </tr>
-</table>
+    </tr>
+    <ng-container *ngFor="let band of group.bands">
+      <tr *ngIf="!isExcluded(band.bandNumber)">
+        <td class="band-name">
+          {{ band.displayName }}
+          <span class="line"></span>
+        </td>
+        <td class="impact" *ngFor="let impact of scenarioImpacts; last as percentageColumn">
+            <ng-container *ngIf="percentageColumn; else totalsColumn">
+              {{ formatPercentage(impact[band.bandNumber], 'report.common.not-measurable' | translate, scenarioImpacts.length > 2) }}
+            </ng-container>
+            <ng-template #totalsColumn>
+              {{ impact[band.bandNumber] | number:'1.0-0':locale }}
+            </ng-template>
+        </td>
+      </tr>
+    </ng-container>
+  </table>
+</ng-container>
+

--- a/frontend/src/app/report/impact-table/impact-table.component.scss
+++ b/frontend/src/app/report/impact-table/impact-table.component.scss
@@ -26,14 +26,6 @@
           padding-bottom: 4px;
         }
       }
-
-      &.excluded {
-        text-decoration: line-through;
-
-        span.line {
-          visibility: hidden;
-        }
-      }
     }
 
     th {

--- a/frontend/src/app/report/impact-table/impact-table.component.ts
+++ b/frontend/src/app/report/impact-table/impact-table.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { BandGroup } from '@data/metadata/metadata.interfaces';
+import { Band, BandGroup } from '@data/metadata/metadata.interfaces';
 import { formatPercentage } from '@src/app/shared/common.util';
 
 @Component({
@@ -16,6 +16,10 @@ export class ImpactTableComponent {
 
   isExcluded(bandNumber: number): boolean {
     return this.scenarioImpacts.every(impacts => !(bandNumber in impacts));
+  }
+
+  groupExcluded(bandGroup: BandGroup): boolean {
+    return bandGroup.bands.every(b => this.isExcluded(b.bandNumber));
   }
 
   formatPercentage(value: number, ersatz: string, relative: boolean) {


### PR DESCRIPTION
The calculation report sheet would previously render "struck out" rows for all components, in the "Impact per pressure/eco component" section, that were not included in the reported calculation.

This has been changed so that, instead of being rendered as table rows with "strike-through" text, the rows won't render in the report sheet at all.

Change suggested by @EdSacre