### PR TITLE
[SYM-728] - Trigger login/resource loading spinner on page reload

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,3 +1,9 @@
+@if (isInitialLoading$ | async) {
+  <div class="loading-overlay">
+    <app-loader></app-loader>
+  </div>
+}
+
 @if (headerTitle !== '') {
   <app-header [title]="headerTitle"></app-header>
 }

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -34,4 +34,17 @@
   app-header ~ .overlay-content {
     margin-top: cns.$header-height;
   }
+
+  .loading-overlay {
+    z-index: 10000;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.40);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -4,22 +4,31 @@ import { CoreModule } from './core/core.module';
 import { TranslationSetupModule } from './app-translation-setup.module';
 import { SharedModule } from '@shared/shared.module';
 import { provideMockStore } from '@ngrx/store/testing';
-import { RouterModule } from "@angular/router";
-import { provideZonelessChangeDetection } from "@angular/core";
+import { RouterModule } from '@angular/router';
+import { provideZonelessChangeDetection } from '@angular/core';
 
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        RouterModule.forRoot([]),
-        CoreModule,
-        TranslationSetupModule
-      ],
+      imports: [SharedModule, RouterModule.forRoot([]), CoreModule, TranslationSetupModule],
       declarations: [AppComponent],
       providers: [
-        provideMockStore({ initialState: { user: {} } }),
         provideZonelessChangeDetection(),
+        provideMockStore({
+          initialState: {
+            user: {
+              loading: false,
+              loadingBaseline: false,
+              redirectUrl: '/map'
+            },
+            area: { loading: false },
+            calculation: {
+              loadingCompoundComparisons: false,
+              loadingLegends: false
+            },
+            metadata: { loading: false }
+          }
+        })
       ]
     }).compileComponents();
   });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,7 +1,11 @@
-import { Component, OnDestroy, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Event, NavigationEnd, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { Observable, Subscription } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';
+
+import { State } from './app-reducer';
+import { UserSelectors } from '@data/user';
 
 @Component({
   selector: 'app-root',
@@ -12,11 +16,15 @@ import { filter, map, mergeMap } from 'rxjs/operators';
 export class AppComponent implements OnDestroy {
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly store = inject<Store<State>>(Store);
 
   headerTitle = '';
+  isInitialLoading$: Observable<boolean>;
   routeDataSubscription: Subscription | undefined;
 
   constructor() {
+    this.isInitialLoading$ = this.store.select(UserSelectors.selectIsInitialLoading);
+
     this.routeDataSubscription = this.router.events
       .pipe(
         filter((e: Event) => e instanceof NavigationEnd),
@@ -27,12 +35,13 @@ export class AppComponent implements OnDestroy {
           }
           return route;
         }),
-        mergeMap(route => route.data)
+        mergeMap((route) => route.data)
       )
-      .subscribe(data => {
+      .subscribe((data) => {
         this.headerTitle = data['headerTitle'] ? data['headerTitle'] : '';
       });
   }
+
   ngOnDestroy() {
     if (this.routeDataSubscription) {
       this.routeDataSubscription.unsubscribe();

--- a/frontend/src/app/login/login.component.html
+++ b/frontend/src/app/login/login.component.html
@@ -68,9 +68,3 @@
 
 <div class="topography" data-position="bottom-left"></div>
 <div class="topography" data-position="top-right"></div>
-
-@if (loading | async) {
-  <div class="loading-overlay">
-    <app-loader></app-loader>
-  </div>
-}

--- a/frontend/src/app/login/login.component.scss
+++ b/frontend/src/app/login/login.component.scss
@@ -185,17 +185,4 @@
     line-height: 2.4rem;
     max-width: 200px;
   }
-
-  .loading-overlay {
-    z-index: 10000;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(255, 255, 255, 0.40);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
 }

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -1,39 +1,40 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { provideMockStore } from '@ngrx/store/testing';
 
+import { LoginComponent } from './login.component';
+import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '@shared/shared.module';
 import { TranslationSetupModule } from '../app-translation-setup.module';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { LoginComponent } from './login.component';
-import { UserSelectors } from '@data/user';
+import { RouterModule } from '@angular/router';
+import { provideZonelessChangeDetection } from '@angular/core';
 
 describe('LoginComponent', () => {
-  let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
+  let component: LoginComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        ReactiveFormsModule,
         SharedModule,
+        ReactiveFormsModule,
         TranslationSetupModule,
+        RouterModule.forRoot([]),
         MatFormFieldModule,
         MatInputModule
       ],
       declarations: [LoginComponent],
       providers: [
+        provideZonelessChangeDetection(),
         provideMockStore({
-          initialState: { user: { baseline: undefined } },
-          selectors: [{ selector: UserSelectors.selectIsInitialLoading, value: false }]
+          initialState: { user: { baseline: undefined } }
         })
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
-
     fixture.detectChanges();
   });
 
@@ -46,9 +47,5 @@ describe('LoginComponent', () => {
     expect(component.loginForm.get('username')).toBeTruthy();
     expect(component.loginForm.get('password')).toBeTruthy();
     expect(component.loginForm.valid).toBeFalse();
-  });
-
-  it('should set loading observable to selectIsInitialLoading', () => {
-    expect(component.loading).toBeTruthy();
   });
 });

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -1,13 +1,12 @@
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { UserActions, UserSelectors } from '@data/user';
 import { environment } from '@src/environments/environment.prod';
 import { State } from '@src/app/app-reducer';
 import { BrandingService } from '@src/app/core/branding/branding.service';
 import buildInfo from '@src/build-info';
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
   selector: 'app-login',
@@ -26,7 +25,6 @@ export class LoginComponent implements OnInit, OnDestroy {
     standalone: false
   });
   errorMessage?: string;
-  loading?: Observable<boolean>;
   env = environment;
   symphonyVersion = buildInfo.version;
   passwordPeekEnabled: boolean;
@@ -49,11 +47,6 @@ export class LoginComponent implements OnInit, OnDestroy {
               : 'login.error.system-unavailable';
         }
       });
-
-    // Only shows the spinner, no navigation here
-    this.loading = this.store
-      .select(UserSelectors.selectIsInitialLoading)
-      .pipe(debounceTime(0), distinctUntilChanged());
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Previously it only triggered during the login flow. Which meant that if you clear parts of your chache or reload the page, the resources will still get reloaded but without showing the spinner.