### PR TITLE
[SYM-728] - Adjust the login spinner timing

### DIFF
--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -53,7 +53,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     // Only shows the spinner, no navigation here
     this.loading = this.store
       .select(UserSelectors.selectIsInitialLoading)
-      .pipe(debounceTime(0), distinctUntilChanged());
+      .pipe(debounceTime(1000), distinctUntilChanged());
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
We have a debounce time of 800 milliseconds
before the navigateAfterInitialLoad$ effect
triggers. This caused the spinner to dissapear
a little too fast and did not make a clean
transition to the map view from the login page.

By adding debounce to the loading state this is
addressed.