### PR TITLE
[SYM-700] - Support several baselines

### DIFF
--- a/frontend/src/app/core/header/header.component.html
+++ b/frontend/src/app/core/header/header.component.html
@@ -9,24 +9,18 @@
       [src]="brandingService.configData.flagSrc"
       [alt]="brandingService.configData.flagAlt"/>
   }
+  @if (baseline$ | async; as baseline) {
+    <span class="baseline-badge">{{ baseline.name }}</span>
+  }
   <app-user-menu-toggle [user]="user$ | async" (click)="toggleOpenMenu('USER')"></app-user-menu-toggle>
 </div>
 <div
   class="header-menu-container"
   [class.is-open]="openState !== 'NONE'"
-  [style.justifyContent]="
-    bothAnimationsAreInProgress
-      ? 'space-between'
-      : animationState.get('user') || openState === 'USER'
-      ? 'flex-end'
-      : 'flex-start'
-  "
 >
   @if (openState === 'USER') {
     <app-menu
       @openCloseMenu
-      (@openCloseMenu.start)="onAnimationStateChange('user')"
-      (@openCloseMenu.done)="onAnimationStateChange('user')"
       (navigate)="onMenuNavigation()"
       [menuItems]="userMenuItems"
       menuLabel="Användarmeny"

--- a/frontend/src/app/core/header/header.component.scss
+++ b/frontend/src/app/core/header/header.component.scss
@@ -40,6 +40,18 @@
       color: inherit;
     }
 
+    .baseline-badge {
+      font-size: 1.4rem;
+      font-weight: 500;
+      color: white;
+      border: 2px solid rgba(255, 255, 255);
+      border-radius: 1rem;
+      padding: 0.2rem 0.8rem;
+      margin-right: 1.2rem;
+      white-space: nowrap;
+      letter-spacing: 0.02em;
+    }
+
     ::ng-deep app-icon {
       font-size: 3rem;
     }

--- a/frontend/src/app/core/header/header.component.spec.ts
+++ b/frontend/src/app/core/header/header.component.spec.ts
@@ -17,7 +17,7 @@ describe('HeaderComponent', () => {
       imports: [SharedModule, StoreModule.forRoot({}, {}), TranslateModule.forRoot()],
       declarations: [HeaderComponent, UserMenuToggleComponent],
       providers: [provideMockStore({
-        initialState : { user: { baseline: undefined } }
+        initialState : { user: { baseline: undefined, availableBaselines: [] } }
         }),
         TranslateService,
         provideZonelessChangeDetection()

--- a/frontend/src/app/core/header/header.component.ts
+++ b/frontend/src/app/core/header/header.component.ts
@@ -1,8 +1,11 @@
-import { Component, Input, OnInit, NgModuleRef, inject } from '@angular/core';
+import { Component, DestroyRef, Input, OnInit, NgModuleRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
 import {
   faInfoCircle,
-  faDoorClosed, IconDefinition
+  faDoorClosed,
+  faLayerGroup,
+  IconDefinition
 } from '@fortawesome/free-solid-svg-icons';
 import { Observable } from 'rxjs';
 import { trigger, style, transition, animate, keyframes } from '@angular/animations';
@@ -14,12 +17,12 @@ import { MenuItem } from '@shared/menu/menu.component';
 import { IconType } from '@shared/icon/icon.component';
 import { DialogService } from "@shared/dialog/dialog.service";
 import { AboutDialogComponent } from "@src/app/core/about/about-dialog.component";
-import { User } from "@data/user/user.interfaces";
+import { Baseline, User } from "@data/user/user.interfaces";
 import { ChangeLanguageDialogComponent } from "@shared/change-language-dialog/change-language-dialog.component";
+import { ChangeBaselineDialogComponent } from "@shared/change-baseline-dialog/change-baseline-dialog.component";
 import { CoreModule } from "@src/app/core/core.module";
 import { BrandingService } from '@src/app/core/branding/branding.service';
 
-type MenuId = 'main' | 'user';
 type OpenState = 'MAIN' | 'USER' | 'NONE';
 
 @Component({
@@ -50,66 +53,55 @@ export class HeaderComponent implements OnInit {
   private readonly store = inject<Store<State>>(Store);
   private readonly dialogService = inject(DialogService);
   private readonly moduleRef = inject(NgModuleRef<CoreModule>);
+  private readonly destroyRef = inject(DestroyRef);
 
   @Input() title: string | undefined;
   menuIcon: IconType = 'menu';
   openState: OpenState = 'NONE';
   userMenuItems?: MenuItem[];
-  bothAnimationsAreInProgress = false;
-  animationState: Map<MenuId, boolean> = new Map<MenuId, boolean>([
-    ['main', false],
-    ['user', false],
-  ]);
   user$: Observable<User | undefined>;
+  baseline$: Observable<Baseline | undefined>;
 
   constructor() {
     this.user$ = this.store.select(UserSelectors.selectUser);
+    this.baseline$ = this.store.select(UserSelectors.selectBaseline);
   }
 
   ngOnInit() {
     if (this.title === undefined) {
       throw new Error('Input property `title` is required.');
     }
-    this.userMenuItems = [
-      {
-        name: 'user-menu.change-language',
-        icon: gmGlobe,
-        click: () => this.changeLanguage(),
-      },
-      {
-        name: 'user-menu.about',
-        icon: faInfoCircle,
-        click: this.about,
-      },
-      {
-        name: 'user-menu.logout',
-        icon: faDoorClosed,
-        click: this.logout,
-      },
-    ];
+    this.store.select(UserSelectors.selectAvailableBaselines).pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(baselines => this.buildUserMenu(baselines));
+  }
 
+  private buildUserMenu(baselines: Baseline[]) {
+    const items: MenuItem[] = [];
     if (environment.externManual) {
-      this.userMenuItems.splice(0, 0, {
-        name: 'user-menu.support',
-        icon: gmHelpCircle,
-        click: this.openManual,
-      });
+      items.push({ name: 'user-menu.support', icon: gmHelpCircle, click: this.openManual });
     }
+    items.push({ name: 'user-menu.change-language', icon: gmGlobe, click: () => this.changeLanguage() });
+    if (baselines.length > 1) {
+      items.push({ name: 'user-menu.change-baseline', icon: faLayerGroup, click: () => this.changeBaseline() });
+    }
+    items.push({ name: 'user-menu.about', icon: faInfoCircle, click: this.about });
+    items.push({ name: 'user-menu.logout', icon: faDoorClosed, click: this.logout });
+    this.userMenuItems = items;
   }
 
   toggleOpenMenu = (newState: OpenState) => {
     this.openState = newState !== this.openState ? newState : 'NONE';
   };
 
-  onAnimationStateChange = (menuId: MenuId) => {
-    this.animationState.set(menuId, !this.animationState.get(menuId));
-    this.bothAnimationsAreInProgress =
-      !!this.animationState.get('user') && !!this.animationState.get('main');
-  };
-
   onMenuNavigation = () => {
     this.openState = 'NONE';
   };
+
+  async changeBaseline() {
+    await this.dialogService.open(ChangeBaselineDialogComponent, this.moduleRef, {});
+    setTimeout(() => this.toggleOpenMenu('NONE'));
+  }
 
   async changeLanguage() {
     const locale: string | undefined = await this.dialogService.open(
@@ -119,8 +111,8 @@ export class HeaderComponent implements OnInit {
     );
     if (locale) {
       this.store.dispatch(UserActions.updateUserSettings({ locale: locale }));
-      this.toggleOpenMenu('NONE');
     }
+    setTimeout(() => this.toggleOpenMenu('NONE'));
   }
 
   about = () => {

--- a/frontend/src/app/data/calculation/calculation.reducers.ts
+++ b/frontend/src/app/data/calculation/calculation.reducers.ts
@@ -1,6 +1,7 @@
 import { createReducer, on } from '@ngrx/store';
 import { setIn } from 'immutable';
 import { CalculationActions, CalculationInterfaces } from './';
+import { UserActions } from '@data/user';
 import { Legend } from '@data/calculation/calculation.interfaces';
 import { ListItemsSort } from '@data/common/sorting.interfaces';
 
@@ -177,6 +178,17 @@ export const calculationReducer = createReducer(
   on(CalculationActions.fetchLegendSuccess, CalculationActions.fetchLegendFailure, (state) => ({
     ...state,
     loadingLegends: false
+  })),
+  on(UserActions.activeBaselineChanged, (state) => ({
+    ...state,
+    calculations: [],
+    batchProcesses: [],
+    compoundComparisons: [],
+    visibleResults: [],
+    loadingResults: [],
+    loadingReports: [],
+    generatingComparisonsFor: [],
+    compoundComparisonSuccessCount: 0
   }))
 );
 

--- a/frontend/src/app/data/calculation/calculation.spec.ts
+++ b/frontend/src/app/data/calculation/calculation.spec.ts
@@ -1,0 +1,37 @@
+import { calculationReducer, initialState } from './calculation.reducers';
+import { CalculationSlice, CompoundComparisonSlice } from './calculation.interfaces';
+import { UserActions } from '@data/user';
+import { Baseline } from '@data/user/user.interfaces';
+
+const baseline: Baseline = { id: 9, name: 'B', description: '' } as Baseline;
+
+describe('CalculationReducer', () => {
+  it('clears all per-baseline arrays on activeBaselineChanged but keeps sort/legend/percentile', () => {
+    const populated = {
+      ...initialState,
+      calculations: [{ id: 1, name: 'c1' } as unknown as CalculationSlice],
+      batchProcesses: { 1: { } as never },
+      compoundComparisons: [{ id: 7 } as unknown as CompoundComparisonSlice],
+      visibleResults: [1, 2],
+      loadingResults: [3],
+      loadingReports: [4],
+      generatingComparisonsFor: [5, 6],
+      compoundComparisonSuccessCount: 3,
+      percentileValue: 0.95
+    };
+
+    const _state = calculationReducer(populated, UserActions.activeBaselineChanged({ baseline }));
+
+    expect(_state.calculations).toEqual([]);
+    expect(_state.batchProcesses).toEqual([] as never);
+    expect(_state.compoundComparisons).toEqual([]);
+    expect(_state.visibleResults).toEqual([]);
+    expect(_state.loadingResults).toEqual([]);
+    expect(_state.loadingReports).toEqual([]);
+    expect(_state.generatingComparisonsFor).toEqual([]);
+    expect(_state.compoundComparisonSuccessCount).toEqual(0);
+    // Preserved by design
+    expect(_state.percentileValue).toEqual(0.95);
+    expect(_state.sortCalculations).toEqual(populated.sortCalculations);
+  });
+});

--- a/frontend/src/app/data/scenario/scenario.reducers.ts
+++ b/frontend/src/app/data/scenario/scenario.reducers.ts
@@ -2,6 +2,7 @@ import { createReducer, on } from '@ngrx/store';
 import Immutable, { removeIn, setIn, updateIn } from 'immutable';
 
 import { CalculationActions } from '@data/calculation';
+import { UserActions } from '@data/user';
 import { BandChange } from "@data/metadata/metadata.interfaces";
 import {
   fetchAreaMatricesFailure,
@@ -342,5 +343,6 @@ export const scenarioReducer = createReducer(
   on(resetAutoBatch, state => ({
     ...state,
     autoBatch: []
-  }))
+  })),
+  on(UserActions.activeBaselineChanged, () => initialState)
 );

--- a/frontend/src/app/data/scenario/scenario.spec.ts
+++ b/frontend/src/app/data/scenario/scenario.spec.ts
@@ -1,0 +1,27 @@
+import { initialState, scenarioReducer } from './scenario.reducers';
+import { Scenario } from './scenario.interfaces';
+import { ListItemsSort } from '@data/common/sorting.interfaces';
+import { UserActions } from '@data/user';
+import { Baseline } from '@data/user/user.interfaces';
+
+const stubScenario = { id: 1, name: 'old' } as unknown as Scenario;
+const baseline: Baseline = { id: 9, name: 'B', description: '' } as Baseline;
+
+describe('ScenarioReducer', () => {
+  it('resets to initial state when the active baseline changes', () => {
+    const populated = {
+      ...initialState,
+      scenarios: [stubScenario],
+      active: 0,
+      activeArea: 0,
+      matrixData: { 1: {} as never },
+      matricesLoading: true,
+      sortScenarios: ListItemsSort.None,
+      autoBatch: [42]
+    };
+
+    const _state = scenarioReducer(populated, UserActions.activeBaselineChanged({ baseline }));
+
+    expect(_state).toEqual(initialState);
+  });
+});

--- a/frontend/src/app/data/user/user.actions.ts
+++ b/frontend/src/app/data/user/user.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from '@ngrx/store';
-import { Baseline, User } from './user.interfaces';
+import { Baseline, User, UserSettings } from './user.interfaces';
 import { ErrorMessage } from '@data/message/message.interfaces';
 
 export const fetchUser = createAction('[User] Fetch user');
@@ -44,6 +44,18 @@ export const logoutUserFailure = createAction(
 
 export const fetchBaseline = createAction('[User] Fetch baseline');
 
+export const fetchAvailableBaselines = createAction('[User] Fetch available baselines');
+
+export const fetchAvailableBaselinesSuccess = createAction(
+  '[User] Fetch available baselines success',
+  props<{ baselines: Baseline[] }>()
+);
+
+export const fetchAvailableBaselinesFailure = createAction(
+  '[User] Fetch available baselines failure',
+  props<{ error: ErrorMessage }>()
+);
+
 export const fetchBaselineSuccess = createAction(
   '[User] Fetch baseline success',
   props<{ baseline: Baseline }>()
@@ -61,7 +73,12 @@ export const updateRedirectUrl = createAction(
 
 export const updateUserSettings = createAction(
   '[User] Update user settings',
-  props<{ aliasing?: boolean, locale?: string }>()
+  props<Partial<UserSettings>>()
+);
+
+export const activeBaselineChanged = createAction(
+  '[User] Active baseline changed',
+  props<{ baseline: Baseline }>()
 );
 
 export const navigateTo = createAction('[User] Navigate to', props<{ url: string }>());

--- a/frontend/src/app/data/user/user.effects.ts
+++ b/frontend/src/app/data/user/user.effects.ts
@@ -20,6 +20,7 @@ import { UserActions, UserSelectors } from './';
 import { AreaActions } from '@data/area';
 import { MetadataActions } from '@data/metadata';
 import { CalculationActions } from '@data/calculation';
+import { ScenarioActions } from '@data/scenario';
 import { LegendType } from '@data/calculation/calculation.interfaces';
 import { UserSettings } from '@data/user/user.interfaces';
 
@@ -131,6 +132,7 @@ export class UserEffects {
         AreaActions.fetchUserDefinedAreas(),
         AreaActions.fetchBoundaries(),
         UserActions.fetchBaseline(),
+        UserActions.fetchAvailableBaselines(),
         CalculationActions.fetchCompoundComparisons(),
         ...legendTypes.map((legendType) => CalculationActions.fetchLegend({ legendType }))
       ])
@@ -161,11 +163,64 @@ export class UserEffects {
   updateUserSettings$ = createEffect(() =>
     this.actions$.pipe(
       ofType(UserActions.updateUserSettings),
-      mergeMap(({ aliasing, locale }) =>
-        this.userService
-          .updateSettings({ aliasing, locale } as UserSettings)
-          .pipe(map(() => (locale ? UserActions.fetchUser() : UserActions.fetchUserSettings())))
+      mergeMap((settings) =>
+        this.userService.updateSettings(settings as UserSettings).pipe(
+          mergeMap(() => {
+            if (settings.activeBaselineId !== undefined) {
+              return this.userService.fetchBaseline().pipe(
+                mergeMap((baseline) => [
+                  UserActions.fetchBaselineSuccess({ baseline }),
+                  UserActions.activeBaselineChanged({ baseline })
+                ])
+              );
+            }
+            return of(
+              settings.locale !== undefined
+                ? UserActions.fetchUser()
+                : UserActions.fetchUserSettings()
+            );
+          }),
+          catchError((error) =>
+            settings.activeBaselineId !== undefined
+              ? of(UserActions.fetchBaselineFailure({
+                  error: { status: error.status, message: error.error?.errorMessage ?? error.message }
+                }))
+              : of(UserActions.fetchUserFailure({
+                  error: { status: error.status, message: error.error?.errorMessage ?? error.message }
+                }))
+          )
+        )
       )
+    )
+  );
+
+  availableBaselinesAreFetched$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(UserActions.fetchAvailableBaselines),
+      mergeMap(() =>
+        this.userService.fetchBaselines().pipe(
+          map((baselines) => UserActions.fetchAvailableBaselinesSuccess({ baselines })),
+          catchError((error) =>
+            of(UserActions.fetchAvailableBaselinesFailure({ error: { status: error.status, message: error.error } }))
+          )
+        )
+      )
+    )
+  );
+
+  activeBaselineChanged$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(UserActions.activeBaselineChanged),
+      concatMap(() => [
+        MetadataActions.fetchMetadata(),
+        ScenarioActions.closeActiveScenario(),
+        ScenarioActions.fetchScenarios(),
+        CalculationActions.setVisibleResultLayers({ visibleResults: [] }),
+        CalculationActions.resetComparisonLegend(),
+        CalculationActions.fetchCalculations(),
+        CalculationActions.fetchCompoundComparisons(),
+        AreaActions.fetchBoundaries(),
+      ])
     )
   );
 

--- a/frontend/src/app/data/user/user.interfaces.ts
+++ b/frontend/src/app/data/user/user.interfaces.ts
@@ -3,6 +3,7 @@ import { ErrorMessage } from '@data/message/message.interfaces';
 export interface UserSettings {
   locale?: string | undefined;
   aliasing?: boolean | undefined;
+  activeBaselineId?: number | undefined;
 }
 
 export interface User {
@@ -17,6 +18,7 @@ export interface State {
   loadingBaseline: boolean;
   redirectUrl: string;
   baseline?: Baseline;
+  availableBaselines?: Baseline[];
   error?: { login?: ErrorMessage };
   aliasing: boolean;
 }

--- a/frontend/src/app/data/user/user.reducers.ts
+++ b/frontend/src/app/data/user/user.reducers.ts
@@ -50,9 +50,17 @@ export const userReducer = createReducer(
       fetch: error
     }
   })),
-  on(UserActions.fetchBaselineSuccess, (state, { baseline }) => ({
+  on(UserActions.fetchBaselineSuccess, UserActions.activeBaselineChanged, (state, { baseline }) => ({
     ...state,
     baseline: baseline
+  })),
+  on(UserActions.fetchAvailableBaselinesSuccess, (state, { baselines }) => ({
+    ...state,
+    availableBaselines: baselines
+  })),
+  on(UserActions.fetchAvailableBaselinesFailure, (state) => ({
+    ...state,
+    availableBaselines: []
   })),
   on(UserActions.updateRedirectUrl, (state, { url }) => ({
     ...state,

--- a/frontend/src/app/data/user/user.selectors.ts
+++ b/frontend/src/app/data/user/user.selectors.ts
@@ -28,6 +28,11 @@ export const selectLoginError = createSelector(selectErrorMessage, (error) =>
 
 export const selectBaseline = createSelector(selectUserState, (state: State) => state.baseline);
 
+export const selectAvailableBaselines = createSelector(
+  selectUserState,
+  (state: State) => state.availableBaselines ?? []
+);
+
 export const selectAliasing = createSelector(selectUserState, (state: State) => state.aliasing);
 
 export const selectIsInitialLoading = createSelector(

--- a/frontend/src/app/data/user/user.service.ts
+++ b/frontend/src/app/data/user/user.service.ts
@@ -27,7 +27,11 @@ export default class UserService {
   fetchBaseline() {
     return this.http.get<UserInterfaces.Baseline>(env.baseline
       ? `${BASE_URL}/baselineversion/name/${env.baseline}`
-      : `${BASE_URL}/baselineversion/current`);
+      : `${BASE_URL}/baselineversion/active`);
+  }
+
+  fetchBaselines() {
+    return this.http.get<UserInterfaces.Baseline[]>(`${BASE_URL}/baselineversion`);
   }
 
   updateSettings(param: UserSettings) {

--- a/frontend/src/app/data/user/user.spec.ts
+++ b/frontend/src/app/data/user/user.spec.ts
@@ -1,16 +1,18 @@
-import { userReducer, initialState } from './user.reducers';
-import { User, State } from './user.interfaces';
+import { initialState, userReducer } from './user.reducers';
+import { Baseline, State, User } from './user.interfaces';
 import { UserActions, UserSelectors } from '.';
 
 const testUser: User = {
-  username: 'Test',
+  username: 'Test'
 };
 
 const user: User = { ...testUser };
 const state: State = { ...initialState };
 
-describe('UserReducer', () => {
+const baselineA: Baseline = { id: 1, name: 'A', description: 'baseline A' } as Baseline;
+const baselineB: Baseline = { id: 2, name: 'B', description: 'baseline B' } as Baseline;
 
+describe('UserReducer', () => {
   it('should set loading to true on login', () => {
     expect(initialState.loading).toEqual(false);
     const _state = userReducer(initialState, UserActions.loginUser);
@@ -25,10 +27,47 @@ describe('UserReducer', () => {
     expect(_state.error).toEqual(undefined);
     expect(_state.user).toEqual(testUser);
   });
+
+  it('should set baseline on fetchBaselineSuccess and clear loadingBaseline', () => {
+    const _state = userReducer(
+      initialState,
+      UserActions.fetchBaselineSuccess({ baseline: baselineA })
+    );
+    expect(_state.baseline).toEqual(baselineA);
+    expect(_state.loadingBaseline).toEqual(false);
+  });
+
+  it('should set baseline on activeBaselineChanged', () => {
+    const prior = userReducer(
+      initialState,
+      UserActions.fetchBaselineSuccess({ baseline: baselineA })
+    );
+    const _state = userReducer(prior, UserActions.activeBaselineChanged({ baseline: baselineB }));
+    expect(_state.baseline).toEqual(baselineB);
+  });
+
+  it('should populate availableBaselines on fetchAvailableBaselinesSuccess', () => {
+    const _state = userReducer(
+      initialState,
+      UserActions.fetchAvailableBaselinesSuccess({ baselines: [baselineA, baselineB] })
+    );
+    expect(_state.availableBaselines).toEqual([baselineA, baselineB]);
+  });
+
+  it('should reset availableBaselines to empty on fetchAvailableBaselinesFailure', () => {
+    const seeded = userReducer(
+      initialState,
+      UserActions.fetchAvailableBaselinesSuccess({ baselines: [baselineA] })
+    );
+    const _state = userReducer(
+      seeded,
+      UserActions.fetchAvailableBaselinesFailure({ error: { status: 500, message: 'boom' } })
+    );
+    expect(_state.availableBaselines).toEqual([]);
+  });
 });
 
 describe('UserSelectors', () => {
-
   it('should return islogged in', () => {
     expect(UserSelectors.selectIsLoggedIn.projector(state)).toEqual(false);
     expect(
@@ -46,5 +85,22 @@ describe('UserSelectors', () => {
         user
       })
     ).toEqual(user);
+  });
+
+  it('should return the active baseline', () => {
+    expect(UserSelectors.selectBaseline.projector(state)).toBeUndefined();
+    expect(UserSelectors.selectBaseline.projector({ ...state, baseline: baselineA })).toEqual(
+      baselineA
+    );
+  });
+
+  it('should return available baselines, falling back to []', () => {
+    expect(UserSelectors.selectAvailableBaselines.projector(state)).toEqual([]);
+    expect(
+      UserSelectors.selectAvailableBaselines.projector({
+        ...state,
+        availableBaselines: [baselineA, baselineB]
+      })
+    ).toEqual([baselineA, baselineB]);
   });
 });

--- a/frontend/src/app/map-view/comparison/comparison.component.ts
+++ b/frontend/src/app/map-view/comparison/comparison.component.ts
@@ -1,14 +1,15 @@
-import { AfterViewInit, Component, NgModuleRef, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, Component, NgModuleRef, OnDestroy, ViewChild, inject } from '@angular/core';
 import { Store } from "@ngrx/store";
 import { State } from '@src/app/app-reducer';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { CalculationSlice } from '@data/calculation/calculation.interfaces';
 import { CalculationActions, CalculationSelectors } from '@data/calculation';
+import { UserSelectors } from '@data/user';
 import { FormBuilder, Validators } from '@angular/forms'; //ValidationErrors, ValidatorFn
 import { DialogService } from '@shared/dialog/dialog.service';
 import { ComparisonReportModalComponent } from '@shared/report-modal/comparison-report-modal.component';
 import { CalculationService } from '@data/calculation/calculation.service';
-import { map, tap } from 'rxjs/operators';
+import { map, skip, tap } from 'rxjs/operators';
 import { TranslateService } from "@ngx-translate/core";
 import { MatSelect } from "@angular/material/select";
 import { MatOption } from "@angular/material/core";
@@ -24,7 +25,7 @@ enum ComparisonScaleOptions { CONSTANT, DYNAMIC }
   styleUrls: ['./comparison.component.scss'],
   standalone: false
 })
-export class ComparisonComponent implements AfterViewInit {
+export class ComparisonComponent implements AfterViewInit, OnDestroy {
   private readonly store = inject<Store<State>>(Store);
   private readonly dialogService = inject(DialogService);
   private readonly calcService = inject(CalculationService);
@@ -47,14 +48,38 @@ export class ComparisonComponent implements AfterViewInit {
   includeUnchanged = false;
   reverseComparison = false;
   computingComparisonResult = false;
+  private baselineSubscription?: Subscription;
 
   constructor() {
     this.calculations$ = this.store.select(CalculationSelectors.selectCalculations);
     this.candidates$ = this.store.select(CalculationSelectors.selectChangedCalculations);
+
+    this.baselineSubscription = this.store.select(UserSelectors.selectBaseline)
+      .pipe(skip(1))
+      .subscribe(() => this.resetForBaselineSwitch());
   }
 
   ngAfterViewInit(): void {
     this.bSelect.disabled = !this.useImplicit;
+  }
+
+  ngOnDestroy(): void {
+    this.baselineSubscription?.unsubscribe();
+  }
+
+  private resetForBaselineSwitch() {
+    this.useImplicit = true;
+    this.includeUnchanged = false;
+    this.candidates$ = this.store.select(CalculationSelectors.selectChangedCalculations);
+    this.compareForm.controls.b.reset();
+    if (this.aSelect) {
+      this.aSelect.value = null;
+    }
+    if (this.bSelect) {
+      this.bSelect.value = null;
+      this.bSelect.disabled = false;
+    }
+    this.loadingCandidates = false;
   }
 
   submit() {

--- a/frontend/src/app/map-view/map/map.component.ts
+++ b/frontend/src/app/map-view/map/map.component.ts
@@ -28,7 +28,7 @@ import { StaticImageOptions } from '@data/calculation/calculation.interfaces';
 import { DialogService } from '@shared/dialog/dialog.service';
 import { CreateUserAreaModalComponent } from './create-user-area-modal/create-user-area-modal.component';
 import { Scenario } from '@data/scenario/scenario.interfaces';
-import { distinctUntilChanged, filter, skip, take } from 'rxjs/operators';
+import { distinctUntilChanged, filter, skip } from 'rxjs/operators';
 import { Feature, Map as OLMap, View } from 'ol';
 import { isNotNullOrUndefined } from '@src/util/rxjs';
 import { TranslateService } from '@ngx-translate/core';
@@ -93,6 +93,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
   private reliabilitySubject$?: Observable<ReliabilityMap | null>;
   private reliabilitySubscription$?: Subscription;
+  private visibleReliabilitySubscription?: Subscription;
 
   // layers
   private background?: BackgroundLayer;
@@ -274,8 +275,15 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       .pipe(skipWhile((reliabilityMap) => reliabilityMap === null));
 
     this.reliabilitySubscription$ = this.reliabilitySubject$
-      .pipe(take(1))
       .subscribe((reliabilityMap) => {
+        if (this.reliabilityLayers) {
+          const layers = this.map!.getLayers();
+          layers.remove(this.reliabilityLayers.ECOSYSTEM);
+          layers.remove(this.reliabilityLayers.PRESSURE);
+          layers.remove(this.reliabilityLayers.ECOSYSTEM_OL);
+          layers.remove(this.reliabilityLayers.PRESSURE_OL);
+        }
+
         this.reliabilityLayers = {
           ECOSYSTEM: new ReliabilityLayer(reliabilityMap!.ECOSYSTEM, true, this.geoJson!),
           PRESSURE: new ReliabilityLayer(reliabilityMap!.PRESSURE, true, this.geoJson!),
@@ -288,34 +296,39 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         this.map!.addLayer(this.reliabilityLayers.ECOSYSTEM_OL);
         this.map!.addLayer(this.reliabilityLayers.PRESSURE_OL);
 
-        this.store
-          .select(MetadataSelectors.selectVisibleReliability)
-          .subscribe((visibleReliability) => {
-            this.reliabilityLayers.ECOSYSTEM.clear();
-            this.reliabilityLayers.PRESSURE.clear();
-            this.reliabilityLayers.ECOSYSTEM_OL.clear();
-            this.reliabilityLayers.PRESSURE_OL.clear();
+        if (!this.visibleReliabilitySubscription) {
+          this.visibleReliabilitySubscription = this.store
+            .select(MetadataSelectors.selectVisibleReliability)
+            .subscribe((visibleReliability) => {
+              if (!this.reliabilityLayers) return;
+              this.reliabilityLayers.ECOSYSTEM.clear();
+              this.reliabilityLayers.PRESSURE.clear();
+              this.reliabilityLayers.ECOSYSTEM_OL.clear();
+              this.reliabilityLayers.PRESSURE_OL.clear();
 
-            if (visibleReliability !== null) {
-              this.showReliability(
-                visibleReliability.band.symphonyCategory,
-                visibleReliability.band.bandNumber,
-                visibleReliability.opaque
-              );
-            }
-          });
+              if (visibleReliability !== null) {
+                this.showReliability(
+                  visibleReliability.band.symphonyCategory,
+                  visibleReliability.band.bandNumber,
+                  visibleReliability.opaque
+                );
+              }
+            });
+        }
       });
 
     this.map!.addLayer(this.areaLayer);
     this.map!.addLayer(this.scenarioLayer);
     this.map!.addLayer(this.areaHighlightLayer);
 
-    this.userSubscription = this.store /* TOOD: Just get from static environment?*/
+    this.userSubscription = this.store
       .select(UserSelectors.selectBaseline)
-      .pipe(isNotNullOrUndefined())
       .pipe(isNotNullOrUndefined())
       .subscribe((baseline) => {
         this.baselineName = baseline.name;
+        if (this.bandLayer) {
+          this.map!.getLayers().remove(this.bandLayer);
+        }
         this.bandLayer = new BandLayer(
           baseline.name,
           this.dataLayerService,
@@ -323,6 +336,9 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           this.aliasing
         );
         this.map!.getLayers().insertAt(1, this.bandLayer); // on top of background layer
+        this.scenarioLayer.clearLayers();
+        this.areaLayer.deselectAreas();
+        this.clearResult();
       });
   }
 
@@ -381,6 +397,12 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     }
     if (this.aliasingSubscription) {
       this.aliasingSubscription.unsubscribe();
+    }
+    if (this.reliabilitySubscription$) {
+      this.reliabilitySubscription$.unsubscribe();
+    }
+    if (this.visibleReliabilitySubscription) {
+      this.visibleReliabilitySubscription.unsubscribe();
     }
 
     this.selectedAreasSubscription.unsubscribe();

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.html
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.html
@@ -1,0 +1,40 @@
+<h4>{{ 'change-baseline-modal.header' | translate }}</h4>
+<div class="baseline-options">
+  @for (baseline of availableBaselines; track baseline.id) {
+    <div
+      class="baseline-option"
+      [ngClass]="{ active: baseline.id === selectedBaselineId }"
+      (click)="selectedBaselineId = baseline.id"
+      tabindex="0"
+    >
+      <div class="baseline-info">
+        <span class="baseline-name">{{ baseline.name }}</span>
+        <span class="baseline-description">{{ baseline.description }}</span>
+      </div>
+      <mat-radio-button
+        [value]="baseline.id"
+        [checked]="baseline.id === selectedBaselineId"
+        (change)="selectedBaselineId = baseline.id">
+      </mat-radio-button>
+    </div>
+  }
+</div>
+<div class="notice">
+  {{ 'change-baseline-modal.notice' | translate }}
+</div>
+@if (error) {
+  <div class="error-banner">{{ error }}</div>
+}
+<div class="button-pane right">
+  <button mat-flat-button [ngClass]="'secondary'" (click)="close()">
+    {{ 'confirmation-modal.cancel' | translate }}
+  </button>
+  <button mat-flat-button (click)="apply()" [disabled]="isApplyDisabled" class="apply-button">
+    <span class="button-text" [class.hidden]="loading">
+      {{ 'change-baseline-modal.apply' | translate }}
+    </span>
+    @if (loading) {
+      <mat-spinner class="button-spinner" [diameter]="20"></mat-spinner>
+    }
+  </button>
+</div>

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.scss
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.scss
@@ -20,6 +20,8 @@
     flex-direction: column;
     margin-top: 2rem;
     gap: 0.8rem;
+    max-height: calc(80vh - 12rem);
+    overflow-y: auto;
 
     .baseline-option {
       display: flex;

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.scss
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.scss
@@ -1,0 +1,94 @@
+@use 'src/styles/hav-colors' as colors;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  width: 44rem;
+  padding: 0 2.4rem 2rem;
+  border-radius: 1rem;
+
+  h4 {
+    margin: 3rem 0 1rem;
+    font-size: 2.2rem;
+    font-weight: 600;
+    color: colors.$hav-black;
+  }
+
+  .baseline-options {
+    display: flex;
+    flex-direction: column;
+    margin-top: 2rem;
+    gap: 0.8rem;
+
+    .baseline-option {
+      display: flex;
+      align-items: center;
+      gap: 1.6rem;
+      padding: 1.2rem 1.6rem;
+      border: 1px solid colors.$hav-map-grey;
+      border-radius: 0.6rem;
+      cursor: pointer;
+      transition: border-color 0.15s;
+
+      &.active,
+      &:hover {
+        border-color: colors.$hav-blue;
+      }
+
+      .baseline-info {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+
+        .baseline-name {
+          font-size: 1.6rem;
+          font-weight: 700;
+          color: colors.$hav-black;
+        }
+
+        .baseline-description {
+          font-size: 1.4rem;
+          color: colors.$hav-darkergrey;
+        }
+      }
+    }
+  }
+
+  .notice {
+    margin-top: 2rem;
+    padding: 1.2rem 1.6rem;
+    background-color: colors.$hav-lightyellow;
+    border-radius: 0.6rem;
+    font-size: 1.4rem;
+    color: colors.$hav-black;
+  }
+
+  .error-banner {
+    margin-top: 1.2rem;
+    padding: 1rem 1.6rem;
+    background-color: colors.$alert-disabled-bg-red;
+    border-radius: 0.6rem;
+    font-size: 1.4rem;
+    color: colors.$red;
+  }
+
+  .button-pane {
+    margin-top: 2.4rem;
+
+    .apply-button {
+      position: relative;
+    }
+
+    .button-text.hidden {
+      visibility: hidden;
+    }
+
+    .button-spinner {
+      position: absolute;
+      inset: 0;
+      margin: auto;
+    }
+  }
+}

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.spec.ts
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Subject } from 'rxjs';
+import { Action } from '@ngrx/store';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { ChangeBaselineDialogComponent } from './change-baseline-dialog.component';
+import { DialogRef } from '@shared/dialog/dialog-ref';
+import { UserActions } from '@data/user';
+import { initialState as user } from '@data/user/user.reducers';
+
+describe('ChangeBaselineDialogComponent', () => {
+  let fixture: ComponentFixture<ChangeBaselineDialogComponent>;
+  let component: ChangeBaselineDialogComponent;
+  let store: MockStore;
+  let actions$: Subject<Action>;
+  let dialogRef: { close: jasmine.Spy };
+
+  beforeEach(() => {
+    actions$ = new Subject<Action>();
+    dialogRef = { close: jasmine.createSpy('close') };
+    TestBed.configureTestingModule({
+      declarations: [ChangeBaselineDialogComponent],
+      imports: [TranslateModule.forRoot(), MatRadioModule, MatProgressSpinnerModule],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideMockStore({ initialState: { user } }),
+        provideMockActions(() => actions$),
+        { provide: DialogRef, useValue: dialogRef }
+      ]
+    });
+    store = TestBed.inject(MockStore);
+    fixture = TestBed.createComponent(ChangeBaselineDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('disables apply until a different baseline is selected', () => {
+    component.activeBaselineId = 1;
+    component.selectedBaselineId = 1;
+    expect(component.isApplyDisabled).toBe(true);
+
+    component.selectedBaselineId = 2;
+    expect(component.isApplyDisabled).toBe(false);
+  });
+
+  it('disables apply while loading', () => {
+    component.activeBaselineId = 1;
+    component.selectedBaselineId = 2;
+    component.loading = true;
+    expect(component.isApplyDisabled).toBe(true);
+  });
+
+  it('dispatches updateUserSettings, sets loading, then closes on activeBaselineChanged', () => {
+    const dispatchSpy = spyOn(store, 'dispatch');
+    component.activeBaselineId = 1;
+    component.selectedBaselineId = 2;
+
+    component.apply();
+
+    expect(component.loading).toBe(true);
+    expect(dispatchSpy).toHaveBeenCalledWith(UserActions.updateUserSettings({ activeBaselineId: 2 }));
+
+    actions$.next(UserActions.activeBaselineChanged({ baseline: { id: 2, name: 'B', description: '', locale: 'sv', validFrom: 0 } }));
+
+    expect(component.loading).toBe(false);
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('clears loading and shows error on fetchBaselineFailure', () => {
+    spyOn(store, 'dispatch');
+    component.activeBaselineId = 1;
+    component.selectedBaselineId = 2;
+
+    component.apply();
+
+    actions$.next(UserActions.fetchBaselineFailure({ error: { status: 404, message: 'Not found' } }));
+
+    expect(component.loading).toBe(false);
+    expect(component.error).toBe('Not found');
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.ts
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.ts
@@ -1,0 +1,72 @@
+import { Component, inject } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { race } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { Actions, ofType } from '@ngrx/effects';
+
+import { DialogRef } from '@shared/dialog/dialog-ref';
+import { State } from '@src/app/app-reducer';
+import { Baseline } from '@data/user/user.interfaces';
+import { UserActions, UserSelectors } from '@data/user';
+
+@Component({
+  selector: 'app-change-baseline-dialog',
+  templateUrl: './change-baseline-dialog.component.html',
+  styleUrls: ['./change-baseline-dialog.component.scss'],
+  standalone: false
+})
+export class ChangeBaselineDialogComponent {
+  private readonly dialog = inject(DialogRef);
+  private readonly store = inject<Store<State>>(Store);
+  private readonly actions$ = inject(Actions);
+
+  availableBaselines: Baseline[] = [];
+  selectedBaselineId: number | undefined;
+  activeBaselineId: number | undefined;
+  loading = false;
+  error: string | undefined;
+
+  constructor() {
+    this.store
+      .select(UserSelectors.selectAvailableBaselines)
+      .pipe(take(1))
+      .subscribe((baselines) => {
+        this.availableBaselines = baselines;
+      });
+
+    this.store
+      .select(UserSelectors.selectBaseline)
+      .pipe(take(1))
+      .subscribe((baseline) => {
+        this.activeBaselineId = baseline?.id;
+        this.selectedBaselineId = baseline?.id;
+      });
+  }
+
+  get isApplyDisabled(): boolean {
+    return this.selectedBaselineId === this.activeBaselineId || this.loading;
+  }
+
+  close() {
+    this.dialog.close();
+  }
+
+  apply() {
+    if (this.selectedBaselineId === undefined) return;
+    this.loading = true;
+    this.error = undefined;
+    race(
+      this.actions$.pipe(ofType(UserActions.activeBaselineChanged), take(1)),
+      this.actions$.pipe(ofType(UserActions.fetchBaselineFailure), take(1))
+    ).subscribe((action) => {
+      this.loading = false;
+      if (action.type === UserActions.fetchBaselineFailure.type) {
+        this.error = (action as ReturnType<typeof UserActions.fetchBaselineFailure>).error?.message
+          ?? 'change-baseline-modal.error';
+      } else {
+        this.dialog.close();
+      }
+    });
+    this.store.dispatch(UserActions.updateUserSettings({ activeBaselineId: this.selectedBaselineId }));
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -41,11 +41,13 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatRadioModule } from "@angular/material/radio";
 import { MatInputModule } from "@angular/material/input";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { ListFilterComponent } from './list-filter/list-filter.component';
 import { MultiToolsComponent } from './multi-tools/multi-tools.component';
 import { MultiActionButtonComponent } from '@shared/multi-action-button/multi-action-button.component';
 import { RenameItemModalComponent} from "@shared/rename-item-modal/rename-item-modal.component";
 import { ChangeLanguageDialogComponent } from './change-language-dialog/change-language-dialog.component';
+import { ChangeBaselineDialogComponent } from './change-baseline-dialog/change-baseline-dialog.component';
 
 @NgModule({
   declarations: [
@@ -89,7 +91,8 @@ import { ChangeLanguageDialogComponent } from './change-language-dialog/change-l
     MultiToolsComponent,
     MultiActionButtonComponent,
     RenameItemModalComponent,
-    ChangeLanguageDialogComponent
+    ChangeLanguageDialogComponent,
+    ChangeBaselineDialogComponent
   ],
     imports: [
         CommonModule,
@@ -101,6 +104,7 @@ import { ChangeLanguageDialogComponent } from './change-language-dialog/change-l
         MatCheckboxModule,
         MatRadioModule,
         MatInputModule,
+        MatProgressSpinnerModule,
         FormsModule
     ],
   exports: [

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -596,7 +596,7 @@
         "support": "Support",
         "profile": "My profile",
         "change-language": "Change language",
-        "change-baseline": "Change baseline",
+        "change-baseline": "Switch baseline",
         "logout": "Log out"
     },
     "about-dialog": {
@@ -625,10 +625,10 @@
         }
     },
     "change-baseline-modal": {
-        "header": "Change baseline",
-        "notice": "Changing the baseline will clear your selected layers, filters, and temporary calculations.",
+        "header": "Switch baseline",
+        "notice": "Switching the baseline will clear your selected layers and filter settings. Your saved scenarios and calculation results are linked to the current baseline.",
         "apply": "Apply",
-        "error": "Failed to change baseline. Please try again."
+        "error": "An error occurred while trying to switch the baseline"
     },
     "report": {
         "calculation": {

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -596,6 +596,7 @@
         "support": "Support",
         "profile": "My profile",
         "change-language": "Change language",
+        "change-baseline": "Change baseline",
         "logout": "Log out"
     },
     "about-dialog": {
@@ -622,6 +623,12 @@
             "sv": "Swedish",
             "fr": "French"
         }
+    },
+    "change-baseline-modal": {
+        "header": "Change baseline",
+        "notice": "Changing the baseline will clear your selected layers, filters, and temporary calculations.",
+        "apply": "Apply",
+        "error": "Failed to change baseline. Please try again."
     },
     "report": {
         "calculation": {

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -626,9 +626,9 @@
     },
     "change-baseline-modal": {
         "header": "Changer la base de référence",
-        "notice": "Changer la base de référence effacera vos couches sélectionnées, filtres et calculs temporaires.",
+        "notice": "Changer la base de référence effacera vos couches sélectionnées et vos paramètres de filtres. Vos scénarios enregistrés et résultats de calcul sont liés à la base de référence actuelle.",
         "apply": "Appliquer",
-        "error": "Impossible de changer la base de référence. Veuillez réessayer."
+        "error": "Une erreur s'est produite lors de la tentative de changer la base de référence"
     },
     "report": {
         "calculation": {

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -596,6 +596,7 @@
         "support": "Mode d'emploi",
         "profile": "Mon profil",
         "change-language": "Changer de langue",
+        "change-baseline": "Changer la base de référence",
         "logout": "Se déconnecter"
     },
     "about-dialog": {
@@ -622,6 +623,12 @@
             "sv": "Suédois",
             "fr": "Français"
         }
+    },
+    "change-baseline-modal": {
+        "header": "Changer la base de référence",
+        "notice": "Changer la base de référence effacera vos couches sélectionnées, filtres et calculs temporaires.",
+        "apply": "Appliquer",
+        "error": "Impossible de changer la base de référence. Veuillez réessayer."
     },
     "report": {
         "calculation": {

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -596,7 +596,7 @@
         "support": "Support",
         "profile": "Min profil",
         "change-language": "Ändra språk",
-        "change-baseline": "Ändra basvärde",
+        "change-baseline": "Byt baseline",
         "logout": "Logga ut"
     },
     "about-dialog": {
@@ -625,10 +625,10 @@
         }
     },
     "change-baseline-modal": {
-        "header": "Ändra basvärde",
-        "notice": "Att ändra basvärde rensar dina valda lager, filter och tillfälliga beräkningar.",
+        "header": "Byt baseline",
+        "notice": "Att byta baseline rensar dina valda lager och filter-inställningar. Dina sparade scenarier och beräkningsresultat är knutna till aktuell baseline.",
         "apply": "Verkställ",
-        "error": "Det gick inte att ändra basvärde. Försök igen."
+        "error": "Ett fel inträffade vid försöket att byta baseline"
     },
     "report": {
         "calculation": {

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -596,6 +596,7 @@
         "support": "Support",
         "profile": "Min profil",
         "change-language": "Ändra språk",
+        "change-baseline": "Ändra basvärde",
         "logout": "Logga ut"
     },
     "about-dialog": {
@@ -622,6 +623,12 @@
             "sv": "Svenska",
             "fr": "Franska"
         }
+    },
+    "change-baseline-modal": {
+        "header": "Ändra basvärde",
+        "notice": "Att ändra basvärde rensar dina valda lager, filter och tillfälliga beräkningar.",
+        "apply": "Verkställ",
+        "error": "Det gick inte att ändra basvärde. Försök igen."
     },
     "report": {
         "calculation": {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationResult.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationResult.java
@@ -70,6 +70,18 @@ import static se.havochvatten.symphony.util.CalculationUtil.operationName;
             "AND s.owner = :username AND c.cares_op = :operation ORDER BY c.cares_timestamp DESC",
     resultSetMapping = "CalculationCmpMapping" )
 
+@NamedNativeQuery(name = "CalculationResult.findCmpByOwnerAndBaseline",
+    query = "SELECT c.cares_id, c.cares_calculationname, c.cares_timestamp, " +
+                    "cs.haschanges, " +
+                    "s.polygon, s.ecosystems, s.pressures FROM " +
+            "calculationresult c " +
+            "JOIN calculationresultslice cs ON c.cares_id = cs.id " +
+            "JOIN scenariosnapshot s ON c.scenariosnapshot_id = s.id "+
+            "AND s.owner = :username AND c.cares_op = :operation " +
+            "AND c.cares_bver_id = :baselineId " +
+            "ORDER BY c.cares_timestamp DESC",
+    resultSetMapping = "CalculationCmpMapping" )
+
 
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class CalculationResult implements Serializable {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationResultSlice.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CalculationResultSlice.java
@@ -35,6 +35,9 @@ import java.util.Date;
 @NamedQuery(name = "CalculationResultSlice.findAllByOwner",
     query = "SELECT c FROM CalculationResultSlice c WHERE c.owner = :owner " +
             "ORDER BY c.timestamp DESC")
+@NamedQuery(name = "CalculationResultSlice.findAllByOwnerAndBaseline",
+    query = "SELECT c FROM CalculationResultSlice c WHERE c.owner = :owner " +
+            "AND c.baselineversionId = :baselineId ORDER BY c.timestamp DESC")
 @Table(name = "calculationresultslice", schema = "symphony")
 public class CalculationResultSlice {
     @Id

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CompoundComparison.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/CompoundComparison.java
@@ -41,6 +41,15 @@ import java.util.Map;
                 "GROUP BY c.id, c.cmp_name, c.cmp_timestamp " +
                 "ORDER BY c.id DESC",
     resultSetMapping = "CompoundCmpSliceMapping" )
+
+@NamedNativeQuery(name = "CompoundComparison.findByOwnerAndBaseline",
+    query = "SELECT c.id, c.cmp_name, c.cmp_timestamp, " +
+                "array_agg(value->>'calculationName') calculationNames " +
+                "FROM compoundcomparison c, json_each(c.cmp_result) " +
+                "WHERE c.cmp_owner = :username AND c.baseline_id = :baselineId " +
+                "GROUP BY c.id, c.cmp_name, c.cmp_timestamp " +
+                "ORDER BY c.id DESC",
+    resultSetMapping = "CompoundCmpSliceMapping" )
 public class CompoundComparison {
 
     @Id

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/Scenario.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/Scenario.java
@@ -33,6 +33,9 @@ import java.util.stream.Collectors;
 @NamedQuery(name = "Scenario.findAllByOwner",
     query = "SELECT NEW se.havochvatten.symphony.dto.ScenarioDto(s) FROM Scenario s" +
             " WHERE s.owner = :owner ORDER BY s.timestamp DESC")
+@NamedQuery(name = "Scenario.findAllByOwnerAndBaseline",
+    query = "SELECT NEW se.havochvatten.symphony.dto.ScenarioDto(s) FROM Scenario s" +
+            " WHERE s.owner = :owner AND s.baselineId = :baselineId ORDER BY s.timestamp DESC")
 @NamedQuery(name = "Scenario.getEcosystemsToInclude",
     query = "SELECT ecosystemsToInclude FROM Scenario WHERE id = :scenarioId")
 @NamedQuery(name = "Scenario.getPressuresToInclude",

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/BaselineVersionService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/BaselineVersionService.java
@@ -1,5 +1,6 @@
 package se.havochvatten.symphony.service;
 
+import se.havochvatten.symphony.dto.UserDto;
 import se.havochvatten.symphony.entity.BaselineVersion;
 import se.havochvatten.symphony.exception.SymphonyModelErrorCode;
 import se.havochvatten.symphony.exception.SymphonyStandardAppException;
@@ -53,6 +54,17 @@ public class BaselineVersionService {
 
     public BaselineVersion getBaselineVersionById(Integer id) {
         return em.find(BaselineVersion.class, id);
+    }
+
+    /**
+     * Resolve the effective baseline for a user: their explicit `activeBaselineId`
+     * setting if set and still valid, otherwise the baseline valid today.
+     */
+    public BaselineVersion getActiveBaselineVersionForUser(UserDto user) throws SymphonyStandardAppException {
+        Object raw = user.getSettings().get("activeBaselineId");
+        Integer activeId = raw instanceof Number n ? n.intValue() : null;
+        BaselineVersion baselineVersion = activeId != null ? getBaselineVersionById(activeId) : null;
+        return baselineVersion != null ? baselineVersion : getBaselineVersionByDate(new Date());
     }
 
     /**

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/CalcService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/CalcService.java
@@ -99,6 +99,8 @@ public class CalcService {
     Operations operations;
     @EJB
     ScenarioService scenarioService;
+    @EJB
+    UserService userService;
 
     @Inject
     private CalculationAreaService calculationAreaService;
@@ -129,8 +131,14 @@ public class CalcService {
                 getResultList();
     }
 
-    public List<CalculationResultSlice> findAllByUser(Principal user) {
-        return findAllByUsername(user.getName());
+    public List<CalculationResultSlice> findAllByUser(Principal user) throws SymphonyStandardAppException, IOException {
+        int baselineId = baselineVersionService
+                .getActiveBaselineVersionForUser(userService.getUser(user))
+                .getId();
+        return em.createNamedQuery("CalculationResultSlice.findAllByOwnerAndBaseline", CalculationResultSlice.class).
+                setParameter("owner", user.getName()).
+                setParameter("baselineId", baselineId).
+                getResultList();
     }
 
     private List<CalculationResultSlice> findAllByUsername(String username) {
@@ -139,10 +147,11 @@ public class CalcService {
                 getResultList();
     }
 
-    public List<CalculationResultSliceDto> findAllCmpByUser(Principal user, int operation) {
-        return em.createNamedQuery("CalculationResult.findCmpByOwner", CalculationResultSliceDto.class).
+    public List<CalculationResultSliceDto> findAllCmpByUser(Principal user, int operation, int baselineId) {
+        return em.createNamedQuery("CalculationResult.findCmpByOwnerAndBaseline", CalculationResultSliceDto.class).
                 setParameter("username", user.getName()).
                 setParameter("operation", operationName(operation)).
+                setParameter("baselineId", baselineId).
                 getResultList();
     }
 
@@ -156,7 +165,7 @@ public class CalcService {
         int operation = base.getOperationName().equals("CumulativeImpact") ?
                 OPERATION_CUMULATIVE : OPERATION_RARITYADJUSTED;
 
-        var candidates = findAllCmpByUser(user, operation);
+        var candidates = findAllCmpByUser(user, operation, base.getBaselineVersion().getId());
         List<Integer> ecoList       = Arrays.stream(base.getScenarioSnapshot().getEcosystemsToInclude()).boxed().toList(),
                       pressureList  = Arrays.stream(base.getScenarioSnapshot().getPressuresToInclude()).boxed().toList();
 
@@ -861,9 +870,13 @@ public class CalcService {
         return (GridCoverage2D) operations.divide(difference, floatbase);
     }
 
-    public List<CompoundComparisonSlice> getCompoundComparisons(Principal user) {
-        return em.createNamedQuery("CompoundComparison.findByOwner", CompoundComparisonSlice.class).
+    public List<CompoundComparisonSlice> getCompoundComparisons(Principal user) throws SymphonyStandardAppException, IOException {
+        int baselineId = baselineVersionService
+                .getActiveBaselineVersionForUser(userService.getUser(user))
+                .getId();
+        return em.createNamedQuery("CompoundComparison.findByOwnerAndBaseline", CompoundComparisonSlice.class).
                 setParameter("username", user.getName()).
+                setParameter("baselineId", baselineId).
                 getResultList();
     }
 

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/ScenarioService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/ScenarioService.java
@@ -72,6 +72,12 @@ public class ScenarioService {
     @EJB
     private CalculationAreaService calculationAreaService;
 
+    @EJB
+    private UserService userService;
+
+    @EJB
+    private BaselineVersionService baselineVersionService;
+
     public Scenario findById(int id) {
         return em.find(Scenario.class, id); // null if not found
     }
@@ -82,8 +88,12 @@ public class ScenarioService {
 
     public List<ScenarioDto> findAllByOwner(Principal principal) {
         try {
-            return em.createNamedQuery("Scenario.findAllByOwner", ScenarioDto.class)
+            int baselineId = baselineVersionService
+                    .getActiveBaselineVersionForUser(userService.getUser(principal))
+                    .getId();
+            return em.createNamedQuery("Scenario.findAllByOwnerAndBaseline", ScenarioDto.class)
                 .setParameter("owner", principal.getName())
+                .setParameter("baselineId", baselineId)
                 .getResultList().stream().filter(s -> s.id != null)
                 .sorted(Comparator.<ScenarioDto>comparingInt(s -> s.id).reversed()).toList();
         } catch (Exception e) {

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/service/UserService.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/service/UserService.java
@@ -25,6 +25,7 @@ import se.havochvatten.symphony.exception.SymphonyModelErrorCode;
 import se.havochvatten.symphony.exception.SymphonyStandardAppException;
 import se.havochvatten.symphony.mapper.UserDefinedAreaDtoMapper;
 
+import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -42,6 +43,9 @@ public class UserService {
     @PersistenceContext(unitName = "symphonyPU")
     private EntityManager em;
     private static final ObjectMapper mapper = new ObjectMapper();
+
+    @EJB
+    private BaselineVersionService baselineVersionService;
 
     /**
      * Find all user defined areas
@@ -256,6 +260,17 @@ public class UserService {
     }
 
     public void updateUserSettings(Principal userPrincipal, Map<String, Object> settings) throws SymphonyStandardAppException {
+        Object rawBaselineId = settings.get("activeBaselineId");
+        if (rawBaselineId != null) {
+            if (!(rawBaselineId instanceof Number)) {
+                throw new SymphonyStandardAppException(SymphonyModelErrorCode.OTHER_ERROR);
+            }
+            int id = ((Number) rawBaselineId).intValue();
+            if (baselineVersionService.getBaselineVersionById(id) == null) {
+                throw new SymphonyStandardAppException(SymphonyModelErrorCode.BASELINE_VERSION_NOT_FOUND);
+            }
+        }
+
         UserSettings userSettings = em.find(UserSettings.class, userPrincipal.getName());
         if (userSettings == null) {
             userSettings = new UserSettings();

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/BaselineVersionServiceREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/BaselineVersionServiceREST.java
@@ -2,18 +2,23 @@ package se.havochvatten.symphony.web;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import se.havochvatten.symphony.dto.UserDto;
 import se.havochvatten.symphony.entity.BaselineVersion;
 import se.havochvatten.symphony.exception.SymphonyStandardAppException;
 import se.havochvatten.symphony.mapper.BaselineVersionDtoMapper;
 import se.havochvatten.symphony.service.BaselineVersionService;
+import se.havochvatten.symphony.service.UserService;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.CacheControl;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
@@ -25,12 +30,33 @@ public class BaselineVersionServiceREST {
     @EJB
     BaselineVersionService baselineVersionService;
 
+    @EJB
+    UserService userService;
+
+    @Context
+    HttpServletRequest req;
+
     @GET
     @Operation(summary = "List all BaselineVersion")
     @Produces({MediaType.APPLICATION_JSON})
     public Response findAll() {
         List<BaselineVersion> baselineVersions = baselineVersionService.findAll();
         return Response.ok(BaselineVersionDtoMapper.mapEntitiesToDtos(baselineVersions)).build();
+    }
+
+    @GET
+    @Operation(summary = "Get active baseline for the current user")
+    @Produces({MediaType.APPLICATION_JSON})
+    @Path("/active")
+    public Response getActive() throws SymphonyStandardAppException, IOException {
+        UserDto user = userService.getUser(req.getUserPrincipal());
+        BaselineVersion baselineVersion = baselineVersionService.getActiveBaselineVersionForUser(user);
+
+        CacheControl cc = new CacheControl();
+        cc.setNoStore(true);
+        return Response.ok(BaselineVersionDtoMapper.mapEntityToDto(baselineVersion))
+                .cacheControl(cc)
+                .build();
     }
 
     @GET
@@ -67,4 +93,5 @@ public class BaselineVersionServiceREST {
                 cacheControl(cc).
                 build();
     }
+
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/CalculationREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/CalculationREST.java
@@ -42,6 +42,7 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.*;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -218,7 +219,8 @@ public class CalculationREST {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Gets all previous computations for the user")
     @RolesAllowed("GRP_SYMPHONY")
-    public List<CalculationResultSlice> getAllCalculations(@Context HttpServletRequest req) {
+    public List<CalculationResultSlice> getAllCalculations(@Context HttpServletRequest req)
+            throws SymphonyStandardAppException, IOException {
         if (req.getUserPrincipal() == null)
             throw new NotAuthorizedException(noPrincipalStr);
         else
@@ -585,7 +587,7 @@ public class CalculationREST {
         try {
             List<CompoundComparisonSlice> comparisons = calcService.getCompoundComparisons(principal);
             return ok(comparisons).build();
-        } catch (SymphonyStandardSystemException sx) {
+        } catch (SymphonyStandardSystemException | SymphonyStandardAppException | IOException sx) {
             return status(Response.Status.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/web/UserREST.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/web/UserREST.java
@@ -223,6 +223,12 @@ public class UserREST {
             userService.updateUserSettings(req.getUserPrincipal(), settings);
             return Response.ok().build();
         } catch (SymphonyStandardAppException e) {
+            if (e.getErrorCode() == SymphonyModelErrorCode.BASELINE_VERSION_NOT_FOUND) {
+                return Response.status(Response.Status.NOT_FOUND).entity(e).build();
+            }
+            if (e.getErrorCode() == SymphonyModelErrorCode.OTHER_ERROR) {
+                return Response.status(Response.Status.BAD_REQUEST).entity(e).build();
+            }
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e).build();
         }
     }

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/web/BaselineVersionServiceRESTTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/web/BaselineVersionServiceRESTTest.java
@@ -5,7 +5,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import se.havochvatten.symphony.dto.BaselineVersionDto;
 
-import java.util.Date;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
@@ -24,14 +23,15 @@ public class BaselineVersionServiceRESTTest extends RESTTest {
     }
 
     @Test
-    public void TestGetCurrent() {
+    public void testGetActive() {
         BaselineVersionDto res = given().
             auth().
             preemptive().
             basic(getUsername(), getPassword()).
             when().
-            get(endpoint("/baselineversion/current")).
+            get(endpoint("/baselineversion/active")).
             then().
+            statusCode(200).
             extract().
             body().
             jsonPath().getObject("", BaselineVersionDto.class);
@@ -40,7 +40,7 @@ public class BaselineVersionServiceRESTTest extends RESTTest {
     }
 
     @Test
-    public void TestGetByName() {
+    public void testGetByName() {
         BaselineVersionDto res = given().
             auth().
             preemptive().
@@ -49,30 +49,12 @@ public class BaselineVersionServiceRESTTest extends RESTTest {
             when().
             get(endpoint("/baselineversion/name/{name}")).
             then().
+            statusCode(200).
             extract().
             body().
             jsonPath().getObject("", BaselineVersionDto.class);
 
         Assert.assertEquals(res.getName(), versions.get(0).getName());
-    }
-
-    @Test
-    public void TestGetByDate() {
-        Date date = versions.get(0).getValidFrom();
-
-        BaselineVersionDto res = given().
-            auth().
-            preemptive().
-            basic(getUsername(), getPassword()).
-            pathParam("date", date).
-            when().
-            get(endpoint("/baselineversion/date/{date}")).
-            then().
-            extract().
-            body().
-            jsonPath().getObject("", BaselineVersionDto.class);
-
-        Assert.assertEquals(res.getValidFrom(), date);
     }
 
     private static List<BaselineVersionDto> getAllBaselineVersions() {

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/web/UserRESTTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/web/UserRESTTest.java
@@ -6,12 +6,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import se.havochvatten.symphony.dto.AreaImportResponse;
+import se.havochvatten.symphony.dto.BaselineVersionDto;
 import se.havochvatten.symphony.dto.UploadedUserDefinedAreaDto;
 import se.havochvatten.symphony.dto.UserDefinedAreaDto;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -267,4 +269,39 @@ public class UserRESTTest extends RESTTest {
         deleteUserDefinedAreaByName("epsg3006");
         deleteUserDefinedAreaByName("espg4326");
 	}
+
+    @Test
+    public void testSetActiveBaselineRoundTripViaUserSettings() {
+        List<BaselineVersionDto> versions = given().
+            auth().preemptive().basic(getUsername(), getPassword()).
+            when().get(endpoint("/baselineversion")).
+            then().extract().body().jsonPath().getList(".", BaselineVersionDto.class);
+
+        BaselineVersionDto target = versions.get(0);
+
+        given().
+            auth().preemptive().basic(getUsername(), getPassword()).
+            contentType("application/json").
+            body(Map.of("activeBaselineId", target.getId())).
+            when().put(endpoint("/user/settings")).
+            then().statusCode(200);
+
+        BaselineVersionDto active = given().
+            auth().preemptive().basic(getUsername(), getPassword()).
+            when().get(endpoint("/baselineversion/active")).
+            then().statusCode(200).
+            extract().body().jsonPath().getObject("", BaselineVersionDto.class);
+
+        assertEquals(target.getId(), active.getId());
+    }
+
+    @Test
+    public void testUserSettingsActiveBaselineUnknownIdReturns404() {
+        given().
+            auth().preemptive().basic(getUsername(), getPassword()).
+            contentType("application/json").
+            body(Map.of("activeBaselineId", Integer.MAX_VALUE)).
+            when().put(endpoint("/user/settings")).
+            then().statusCode(404);
+    }
 }


### PR DESCRIPTION
This change makes it possible to switch the active raster baseline from within the running application, without restarting or reconfiguring the server. The choice is per user and is persisted across sessions, so the next time the user logs in they land back on their last-used baseline.

A new "Change baseline" entry is shown in the user menu (next to "Change language") whenever more than one baseline is configured on the server. Picking it opens a dialog listing the available datasets; selecting one and confirming updates the user's active baseline and refreshes the application state to reflect the new choice. The active baseline name is also shown as a small badge next to the user menu in the header so the current choice stays visible at all times.

After switching baseline:
- The map's underlying band layer and the ecosystem/pressure reliability overlays are rebuilt against the new baseline's rasters.
- The side-panel lists for scenarios, calculations and compound comparisons are reloaded and now show only the items that belong to the newly active baseline. Items from other baselines remain stored on the server and become visible again if the user switches back.
- Any active scenario, scenario polygon, area selection and previously rendered calculation heatmap is cleared from the map, so the user starts from a clean canvas rather than seeing leftover artefacts from the previous baseline.
- The "Compare" view resets to its initial state, which prevents a previously chosen base calculation from holding on to candidates that no longer apply.

Scenarios, calculations and compound comparisons are tied to a single baseline. The corresponding endpoints now consider the user's active baseline server-side, both for the side-panel lists and for the "matching candidates" lookup used inside the Compare view. This removes any overlap between baselines in the UI.

Deployments with a single configured baseline behave as before: the menu entry is only shown when more than one baseline is available. Users who have not yet made an explicit choice fall back to the date-current baseline, matching the previous default behaviour.