### PR TITLE
SYM-700: Optional 'tidy' Baseline version title

### DIFF
--- a/frontend/src/app/core/header/header.component.html
+++ b/frontend/src/app/core/header/header.component.html
@@ -10,7 +10,7 @@
       [alt]="brandingService.configData.flagAlt"/>
   }
   @if (baseline$ | async; as baseline) {
-    <span class="baseline-badge">{{ baseline.name }}</span>
+    <span class="baseline-badge">{{ baseline.title || baseline.name }}</span>
   }
   <app-user-menu-toggle [user]="user$ | async" (click)="toggleOpenMenu('USER')"></app-user-menu-toggle>
 </div>

--- a/frontend/src/app/data/user/user.interfaces.ts
+++ b/frontend/src/app/data/user/user.interfaces.ts
@@ -29,4 +29,5 @@ export interface Baseline {
   description: string;
   locale: string;
   validFrom: number; // datetime
+  title: string | null;
 }

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.html
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.html
@@ -8,7 +8,7 @@
       tabindex="0"
     >
       <div class="baseline-info">
-        <span class="baseline-name">{{ baseline.name }}</span>
+        <span class="baseline-name">{{ baseline.title || baseline.name }}</span>
         <span class="baseline-description">{{ baseline.description }}</span>
       </div>
       <mat-radio-button

--- a/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.spec.ts
+++ b/frontend/src/app/shared/change-baseline-dialog/change-baseline-dialog.component.spec.ts
@@ -69,7 +69,7 @@ describe('ChangeBaselineDialogComponent', () => {
     expect(component.loading).toBe(true);
     expect(dispatchSpy).toHaveBeenCalledWith(UserActions.updateUserSettings({ activeBaselineId: 2 }));
 
-    actions$.next(UserActions.activeBaselineChanged({ baseline: { id: 2, name: 'B', description: '', locale: 'sv', validFrom: 0 } }));
+    actions$.next(UserActions.activeBaselineChanged({ baseline: { id: 2, name: 'B', description: '', locale: 'sv', validFrom: 0, title: 'Some baseline' } }));
 
     expect(component.loading).toBe(false);
     expect(dialogRef.close).toHaveBeenCalled();

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/dto/BaselineVersionDto.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/dto/BaselineVersionDto.java
@@ -8,6 +8,7 @@ public class BaselineVersionDto {
     private String description;
     private String locale;
     private Date validFrom;
+    private String title;
 
     public Integer getId() {
         return id;
@@ -47,5 +48,13 @@ public class BaselineVersionDto {
 
     public void setLocale(String locale) {
         this.locale = locale;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/entity/BaselineVersion.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/entity/BaselineVersion.java
@@ -63,6 +63,9 @@ public class BaselineVersion implements Serializable {
     @Column(name = "bver_presfilepath")
     String pressuresFilePath;
 
+    @Column(name = "bver_title", length = Integer.MAX_VALUE)
+    private String title;
+
     public BaselineVersion() {}
 
     public Integer getId() {
@@ -150,5 +153,13 @@ public class BaselineVersion implements Serializable {
 
     public void setLocale(String locale) {
         this.locale = locale;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String bverTitle) {
+        this.title = bverTitle;
     }
 }

--- a/symphony-ws/src/main/java/se/havochvatten/symphony/mapper/BaselineVersionDtoMapper.java
+++ b/symphony-ws/src/main/java/se/havochvatten/symphony/mapper/BaselineVersionDtoMapper.java
@@ -15,6 +15,7 @@ public class BaselineVersionDtoMapper {
         dto.setDescription(baselineVersion.getDescription());
         dto.setLocale(baselineVersion.getLocale());
         dto.setValidFrom(baselineVersion.getValidFrom());
+        dto.setTitle(baselineVersion.getTitle());
         return dto;
     }
 

--- a/symphony-ws/src/test/java/se/havochvatten/symphony/mapper/BaselineVersionDtoMapperTest.java
+++ b/symphony-ws/src/test/java/se/havochvatten/symphony/mapper/BaselineVersionDtoMapperTest.java
@@ -20,6 +20,7 @@ public class BaselineVersionDtoMapperTest {
         baselineVersion.setDescription("test desc");
         baselineVersion.setLocale("sv_SE");
         baselineVersion.setValidFrom(new Date());
+        baselineVersion.setTitle("title");
     }
 
     @Test
@@ -30,6 +31,7 @@ public class BaselineVersionDtoMapperTest {
         assertEquals(dto.getDescription(), baselineVersion.getDescription());
         assertEquals(dto.getLocale(), baselineVersion.getLocale());
         assertEquals(dto.getValidFrom(), baselineVersion.getValidFrom());
+        assertEquals(dto.getTitle(), baselineVersion.getTitle());
     }
 
 }


### PR DESCRIPTION
Adds an optional 'readable' title property to the `BaselineVersion` entity, suitable for graphical representation. 
PR includes a change in the GUI to support said property so that the representation of optional/current baseline versions will prefer the title field if it's been set, and otherwise fall back to the `name` property.

Assuming the db schema name `symphony`, this script may be used to update the data source in place:
```sql
ALTER TABLE symphony.baselineversion
    ADD bver_title TEXT;
```

