### PR TITLE
feat(map-view): add Layer Manager panel

### DIFF
--- a/frontend/src/app/map-view/layer-manager/auto-select.directive.ts
+++ b/frontend/src/app/map-view/layer-manager/auto-select.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, ElementRef, OnInit } from '@angular/core';
+
+@Directive({ selector: '[appAutoSelect]', standalone: false })
+export class AutoSelectDirective implements OnInit {
+  constructor(private el: ElementRef<HTMLInputElement>) {}
+
+  ngOnInit() {
+    // Defer past Angular's current change detection pass so the browser
+    // has painted the element before we attempt focus + select.
+    setTimeout(() => {
+      this.el.nativeElement.focus();
+      this.el.nativeElement.select();
+    });
+  }
+}

--- a/frontend/src/app/map-view/layer-manager/layer-manager.component.html
+++ b/frontend/src/app/map-view/layer-manager/layer-manager.component.html
@@ -1,0 +1,115 @@
+<div class="layer-manager" [class.collapsed]="!isExpanded" cdkDrag>
+
+  <div class="layer-manager-header" cdkDragHandle>
+    <h3>{{ 'map.layer-manager.title' | translate }}</h3>
+    <i
+      class="info-icon"
+      [title]="'map.layer-manager.info' | translate">ℹ️</i>
+  </div>
+
+  <div class="layer-manager-content">
+
+    <div class="layer-section primary-layers">
+      <div class="section-title">{{ 'map.layer-manager.sections.map-layers' | translate }}</div>
+      <div class="layer-list-static">
+        @for (layer of primaryLayers; track layer.id) {
+          <div class="layer-item">
+            <input
+              type="checkbox"
+              [checked]="layer.visible"
+              (change)="toggleVisibility(layer)"
+              [title]="'map.layer-manager.tooltips.toggle-visibility' | translate"
+            />
+
+            <span class="layer-name">{{ layer.name }}</span>
+
+            <input
+              class="opacity-slider"
+              type="range"
+              min="0"
+              max="100"
+              [value]="getOpacity(layer)"
+              (input)="changeOpacity(layer, +$any($event.target).value)"
+              [title]="'map.layer-manager.tooltips.adjust-opacity' | translate"
+            />
+          </div>
+        }
+      </div>
+    </div>
+
+    @if (secondaryLayers.length > 0) {
+      <div class="layer-section secondary-layers">
+        <div class="section-title">{{ 'map.layer-manager.sections.active-layers' | translate }}</div>
+        <div
+          cdkDropList
+          [cdkDropListData]="secondaryLayers"
+          (cdkDropListDropped)="drop($event)"
+          class="layer-list"
+        >
+          @for (item of secondaryLayers; track item.id) {
+            <div
+              class="layer-item"
+              cdkDrag
+              [cdkDragData]="item"
+            >
+              <span
+                class="drag-handle"
+                cdkDragHandle
+                [title]="'map.layer-manager.tooltips.reorder-layer' | translate">☰</span>
+
+              <input
+                type="checkbox"
+                [checked]="item.visible"
+                (change)="toggleVisibility(item)"
+                [title]="'map.layer-manager.tooltips.toggle-visibility' | translate"
+              />
+
+              @if (editingLayerId !== item.id) {
+                <span
+                  class="layer-name"
+                  [class.editable]="isRenamable(item)"
+                  (click)="startEditing(item)"
+                  [title]="isRenamable(item) ? ('map.layer-manager.tooltips.rename-layer' | translate) : ''">
+                  {{ item.name }}
+                </span>
+              } @else {
+                <input
+                  type="text"
+                  class="layer-name-edit"
+                  [(ngModel)]="editingName"
+                  (blur)="saveLayerName(item)"
+                  (keydown)="onEditKeydown($event, item)"
+                  appAutoSelect
+                />
+                <button
+                  class="confirm-btn"
+                  [title]="'map.layer-manager.tooltips.confirm-rename' | translate"
+                  (mousedown.prevent)="saveLayerName(item)"
+                >✓</button>
+              }
+
+              <input
+                class="opacity-slider"
+                type="range"
+                min="0"
+                max="100"
+                [value]="getOpacity(item)"
+                (input)="changeOpacity(item, +$any($event.target).value)"
+                [title]="'map.layer-manager.tooltips.adjust-opacity' | translate"
+              />
+
+              <button
+                class="remove-btn"
+                [title]="'map.layer-manager.tooltips.remove-layer' | translate"
+                (click)="removeLayer(item)"
+              >
+                ✕
+              </button>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+  </div>
+</div>

--- a/frontend/src/app/map-view/layer-manager/layer-manager.component.scss
+++ b/frontend/src/app/map-view/layer-manager/layer-manager.component.scss
@@ -1,0 +1,187 @@
+.layer-manager {
+  position: absolute;
+  top: 300px;
+  right: 70px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  z-index: 2000;
+  width: 340px;
+  max-height: 600px;
+  display: flex;
+  flex-direction: column;
+
+  &.collapsed {
+    display: none;
+  }
+
+  .layer-manager-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid #e5e5e5;
+    cursor: move;
+    background: #f8f9fa;
+    border-radius: 8px 8px 0 0;
+    user-select: none;
+
+    h3 {
+      font-size: 15px;
+      margin: 0;
+      color: #333;
+      font-weight: 600;
+    }
+
+    .info-icon {
+      font-size: 16px;
+      cursor: help;
+      opacity: 0.6;
+      transition: opacity 0.2s;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
+
+  .layer-manager-content {
+    overflow-y: auto;
+    overflow-x: hidden;
+    max-height: 520px;
+    padding: 8px;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: #f1f1f1;
+      border-radius: 3px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #c1c1c1;
+      border-radius: 3px;
+
+      &:hover {
+        background: #a8a8a8;
+      }
+    }
+  }
+
+  .layer-section {
+    margin-bottom: 12px;
+
+    .section-title {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      color: #666;
+      margin-bottom: 6px;
+      padding: 0 4px;
+      letter-spacing: 0.5px;
+    }
+  }
+
+  .layer-list,
+  .layer-list-static {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+    .layer-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    border: 1px solid #e5e5e5;
+    border-radius: 6px;
+    background: #fafafa;
+    transition: background 0.2s;
+
+    &:hover {
+      background: #f0f0f0;
+    }
+
+    .drag-handle {
+      cursor: grab;
+      user-select: none;
+      font-size: 14px;
+      opacity: 0.5;
+      flex-shrink: 0;
+
+      &:hover {
+        opacity: 1;
+      }
+
+      &:active {
+        cursor: grabbing;
+      }
+    }
+
+    input[type="checkbox"] {
+      cursor: pointer;
+      flex-shrink: 0;
+      width: 16px;
+      height: 16px;
+    }
+
+    .layer-name {
+      flex-grow: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: #333;
+      font-size: 13px;
+      padding: 2px 4px;
+      border-radius: 3px;
+
+      &.editable {
+        cursor: pointer;
+
+        &:hover {
+          background: rgba(0, 123, 255, 0.1);
+        }
+      }
+    }
+
+    .layer-name-edit {
+      flex-grow: 1;
+      font-size: 13px;
+      padding: 2px 4px;
+      border: 1px solid #007bff;
+      border-radius: 3px;
+      outline: none;
+
+      &:focus {
+        box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.2);
+      }
+    }
+
+    .opacity-slider {
+      width: 80px;
+      flex-shrink: 0;
+      cursor: pointer;
+      accent-color: #007bff;
+    }
+
+    .remove-btn {
+      border: none;
+      background: none;
+      color: #dc3545;
+      font-size: 18px;
+      cursor: pointer;
+      padding: 0 4px;
+      flex-shrink: 0;
+      line-height: 1;
+
+      &:hover {
+        color: #a02834;
+      }
+    }
+  }
+}

--- a/frontend/src/app/map-view/layer-manager/layer-manager.component.spec.ts
+++ b/frontend/src/app/map-view/layer-manager/layer-manager.component.spec.ts
@@ -1,0 +1,245 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { LayerManagerComponent, BandLayerItem, ResultLayerItem } from './layer-manager.component';
+import { AutoSelectDirective } from './auto-select.directive';
+import { provideMockStore } from '@ngrx/store/testing';
+import { SharedModule } from '@shared/shared.module';
+import { TranslationSetupModule } from '@src/app/app-translation-setup.module';
+import { StoreModule } from '@ngrx/store';
+import { LayerStyleService } from '../map/layers/layer-style.service';
+import { ResultLayerService } from '../map/layers/result-layer.service';
+import { CalculationService } from '@data/calculation/calculation.service';
+import { DragDropModule, CdkDragDrop } from '@angular/cdk/drag-drop';
+import { of } from 'rxjs';
+import { TranslateLoader } from '@ngx-translate/core';
+import { MetadataSelectors } from '@data/metadata';
+import { CalculationSelectors } from '@data/calculation';
+import { initialState as calculation } from '@data/calculation/calculation.reducers';
+import { initialState as metadata } from '@data/metadata/metadata.reducers';
+import { initialState as user } from '@data/user/user.reducers';
+
+function makeDrop(previousIndex: number, currentIndex: number): CdkDragDrop<(BandLayerItem | ResultLayerItem)[]> {
+  return { previousIndex, currentIndex } as CdkDragDrop<(BandLayerItem | ResultLayerItem)[]>;
+}
+
+function makeBandItem(bandNumber: number): BandLayerItem {
+  return {
+    kind: 'band',
+    id: `eco-${bandNumber}`,
+    name: `Band ${bandNumber}`,
+    type: 'ECOSYSTEM',
+    visible: true,
+    band: {
+      bandNumber,
+      title: `Band ${bandNumber}`,
+      symphonyCategory: 'ECOSYSTEM',
+      selected: true,
+      reliability: null,
+      meta: {}
+    }
+  };
+}
+
+function makeResultItem(id: number): ResultLayerItem {
+  return {
+    kind: 'result',
+    id: `result-${id}`,
+    name: `Result ${id}`,
+    visible: true,
+    entry: {
+      id,
+      name: `Result ${id}`,
+      layer: { getVisible: () => true } as any
+    }
+  };
+}
+
+describe('LayerManagerComponent', () => {
+  let component: LayerManagerComponent;
+  let fixture: ComponentFixture<LayerManagerComponent>;
+
+  const mockLayerStyleService = {
+    getOpacity: () => 1,
+    getResultOpacity: () => 1,
+    getBandVisibility: () => true,
+    setOpacity: () => {},
+    setResultOpacity: () => {},
+    setBandVisibility: () => {},
+    clearResultOpacity: () => {},
+    reorderSecondaryLayers: jasmine.createSpy('reorderSecondaryLayers')
+  };
+
+  const mockResultLayerService = {
+    results$: of([])
+  };
+
+  const mockCalculationService = {
+    removeResultPixels: () => {}
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SharedModule, TranslationSetupModule, StoreModule.forRoot({}, {}), DragDropModule],
+      declarations: [LayerManagerComponent, AutoSelectDirective],
+      providers: [
+        provideMockStore({
+          initialState: { calculation, metadata, user },
+          selectors: [
+            { selector: MetadataSelectors.selectVisibleBands, value: { ecoComponent: [], pressureComponent: [] } },
+            { selector: CalculationSelectors.selectCalculations, value: [] }
+          ]
+        }),
+        { provide: LayerStyleService, useValue: mockLayerStyleService },
+        { provide: ResultLayerService, useValue: mockResultLayerService },
+        { provide: CalculationService, useValue: mockCalculationService },
+        { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+        provideZonelessChangeDetection()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LayerManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize with empty secondary layer list', () => {
+    expect(component.secondaryLayers).toEqual([]);
+  });
+
+  it('should toggle primary layer visibility', () => {
+    const layer = component.primaryLayers[0];
+    const initialVisible = layer.visible;
+    component.toggleVisibility(layer);
+    expect(layer.visible).toBe(!initialVisible);
+  });
+
+  it('should initialize primary layers without the scenario layer', () => {
+    expect(component.primaryLayers.map(layer => layer.id)).toEqual(['background', 'user-areas']);
+  });
+
+  it('should only allow renaming result layers', () => {
+    expect(component.isRenamable(makeResultItem(1))).toBe(true);
+    expect(component.isRenamable(makeBandItem(1))).toBe(false);
+    expect(component.isRenamable(component.primaryLayers[0])).toBe(false);
+  });
+
+  it('should not enter edit mode for primary layers', () => {
+    const layer = component.primaryLayers[0];
+    component.startEditing(layer);
+    expect(component.editingLayerId).toBeNull();
+  });
+
+  it('should not enter edit mode for band layers', () => {
+    component.startEditing(makeBandItem(1));
+    expect(component.editingLayerId).toBeNull();
+  });
+
+  it('should enter and cancel edit mode', () => {
+    const layer = makeResultItem(1);
+    component.startEditing(layer);
+    expect(component.editingLayerId).toBe(layer.id);
+    expect(component.editingName).toBe(layer.name);
+    component.cancelEditing();
+    expect(component.editingLayerId).toBeNull();
+    expect(component.editingName).toBe('');
+  });
+
+  it('should save a renamed layer locally', () => {
+    const layer = makeResultItem(1);
+    component.startEditing(layer);
+    component.editingName = 'My Custom Name';
+    component.saveLayerName(layer);
+    expect(layer.name).toBe('My Custom Name');
+    expect(component.editingLayerId).toBeNull();
+  });
+
+  it('should cancel editing when name is unchanged', () => {
+    const layer = makeResultItem(1);
+    component.startEditing(layer);
+    component.editingName = layer.name;
+    component.saveLayerName(layer);
+    expect(component.editingLayerId).toBeNull();
+  });
+
+  it('should not rename when name is blank', () => {
+    const layer = makeResultItem(1);
+    const nameBefore = layer.name;
+    component.startEditing(layer);
+    component.editingName = '   ';
+    component.saveLayerName(layer);
+    expect(layer.name).toBe(nameBefore);
+  });
+
+  it('should save layer name on Enter key', () => {
+    const layer = makeResultItem(1);
+    component.startEditing(layer);
+    component.editingName = 'New Name';
+    component.onEditKeydown(new KeyboardEvent('keydown', { key: 'Enter' }), layer);
+    expect(layer.name).toBe('New Name');
+  });
+
+  it('should cancel editing on Escape key', () => {
+    const layer = makeResultItem(1);
+    component.startEditing(layer);
+    component.editingName = 'New Name';
+    component.onEditKeydown(new KeyboardEvent('keydown', { key: 'Escape' }), layer);
+    expect(component.editingLayerId).toBeNull();
+  });
+
+  describe('drop()', () => {
+    beforeEach(() => {
+      mockLayerStyleService.reorderSecondaryLayers.calls.reset();
+    });
+
+    it('should reorder secondaryLayers array when dropped', () => {
+      const band1 = makeBandItem(1);
+      const band2 = makeBandItem(2);
+      const band3 = makeBandItem(3);
+      component.secondaryLayers = [band1, band2, band3];
+
+      component.drop(makeDrop(2, 0));
+
+      expect(component.secondaryLayers).toEqual([band3, band1, band2]);
+    });
+
+    it('should call reorderSecondaryLayers with correct band payload', () => {
+      const band = makeBandItem(5);
+      component.secondaryLayers = [band];
+
+      component.drop(makeDrop(0, 0));
+
+      expect(mockLayerStyleService.reorderSecondaryLayers).toHaveBeenCalledOnceWith([
+        { kind: 'band', type: 'ECOSYSTEM', bandNumber: 5 }
+      ]);
+    });
+
+    it('should call reorderSecondaryLayers with correct result payload', () => {
+      const result = makeResultItem(42);
+      component.secondaryLayers = [result];
+
+      component.drop(makeDrop(0, 0));
+
+      expect(mockLayerStyleService.reorderSecondaryLayers).toHaveBeenCalledOnceWith([
+        { kind: 'result', id: 42 }
+      ]);
+    });
+
+    it('should call reorderSecondaryLayers with mixed layers in new order', () => {
+      const band = makeBandItem(1);
+      const result = makeResultItem(10);
+      component.secondaryLayers = [band, result];
+
+      // Move result to front
+      component.drop(makeDrop(1, 0));
+
+      expect(mockLayerStyleService.reorderSecondaryLayers).toHaveBeenCalledOnceWith([
+        { kind: 'result', id: 10 },
+        { kind: 'band', type: 'ECOSYSTEM', bandNumber: 1 }
+      ]);
+    });
+  });
+});

--- a/frontend/src/app/map-view/layer-manager/layer-manager.component.ts
+++ b/frontend/src/app/map-view/layer-manager/layer-manager.component.ts
@@ -1,0 +1,282 @@
+import { Component, OnInit, OnDestroy, Input, ChangeDetectorRef } from '@angular/core';
+import { combineLatest, Subscription, take } from 'rxjs';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Store } from '@ngrx/store';
+import { State } from '@src/app/app-reducer';
+import { Band, BandType } from '@data/metadata/metadata.interfaces';
+import { MetadataSelectors, MetadataActions } from '@data/metadata';
+import { CalculationSelectors } from '@data/calculation';
+import { LayerStyleService } from '../map/layers/layer-style.service';
+import { ResultLayerService, ResultEntry } from '../map/layers/result-layer.service';
+import { CalculationService } from '@data/calculation/calculation.service';
+import { TranslateService } from '@ngx-translate/core';
+
+interface LayerInstance {
+  setVisible?(visible: boolean): void;
+  setOpacity?(opacity: number): void;
+}
+
+interface BaseLayerItem {
+  id: string;
+  name: string;
+}
+
+export interface PrimaryLayerItem extends BaseLayerItem {
+  kind: 'primary';
+  visible: boolean;
+  opacity: number;
+  instance: LayerInstance | null;
+}
+
+export interface BandLayerItem extends BaseLayerItem {
+  kind: 'band';
+  band: Band;
+  type: BandType;
+  visible: boolean;
+}
+
+export interface ResultLayerItem extends BaseLayerItem {
+  kind: 'result';
+  entry: ResultEntry;
+  visible: boolean;
+}
+
+export type LayerItem = PrimaryLayerItem | BandLayerItem | ResultLayerItem;
+
+@Component({
+  selector: 'app-layer-manager',
+  templateUrl: './layer-manager.component.html',
+  styleUrls: ['./layer-manager.component.scss'],
+  standalone: false
+})
+export class LayerManagerComponent implements OnInit, OnDestroy {
+  @Input() isExpanded = false;
+
+  primaryLayers: PrimaryLayerItem[] = [];
+  secondaryLayers: (BandLayerItem | ResultLayerItem)[] = [];
+
+  editingLayerId: string | null = null;
+  editingName = '';
+
+  // Local name overrides — store is source-of-truth on first load, edits stay local
+  private nameOverrides = new Map<string, string>();
+
+  private sub?: Subscription;
+  private langSub?: Subscription;
+
+  constructor(
+    private store: Store<State>,
+    public layerStyleService: LayerStyleService,
+    private resultLayerService: ResultLayerService,
+    private calcService: CalculationService,
+    private translateService: TranslateService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    this.initializePrimaryLayers();
+    this.langSub = this.translateService.onLangChange.subscribe(() => this.updatePrimaryLayerNames());
+
+    this.sub = combineLatest([
+      this.store.select(MetadataSelectors.selectVisibleBands),
+      this.resultLayerService.results$,
+      this.store.select(CalculationSelectors.selectCalculations)
+    ]).subscribe(([components, results, calculations]) => {
+      const bands: BandLayerItem[] = components.ecoComponent.map(b => ({
+        kind: 'band' as const,
+        id: `${b.symphonyCategory}-${b.bandNumber}`,
+        name: this.nameOverrides.get(`${b.symphonyCategory}-${b.bandNumber}`) ?? b.title,
+        band: b,
+        type: 'ECOSYSTEM' as BandType,
+        visible: this.layerStyleService.getBandVisibility('ECOSYSTEM', b.bandNumber)
+      })).concat(components.pressureComponent.map(b => ({
+        kind: 'band' as const,
+        id: `${b.symphonyCategory}-${b.bandNumber}`,
+        name: this.nameOverrides.get(`${b.symphonyCategory}-${b.bandNumber}`) ?? b.title,
+        band: b,
+        type: 'PRESSURE' as BandType,
+        visible: this.layerStyleService.getBandVisibility('PRESSURE', b.bandNumber)
+      })));
+
+      const resultItems: ResultLayerItem[] = results.map(r => {
+        const id = `result-${r.id}`;
+        const calcName = calculations.find(c => c.id === r.id)?.name;
+        return {
+          kind: 'result' as const,
+          id,
+          name: this.nameOverrides.get(id) ?? calcName ?? r.name,
+          entry: r,
+          visible: r.layer.getVisible()
+        };
+      });
+
+      this.secondaryLayers = [...bands, ...resultItems];
+      this.cdr.markForCheck();
+    });
+  }
+
+  ngOnDestroy() {
+    this.sub?.unsubscribe();
+    this.langSub?.unsubscribe();
+  }
+
+  private readonly primaryLayerKeys = [
+    'map.layer-manager.layer-names.background',
+    'map.layer-manager.layer-names.user-areas'
+  ];
+
+  private readonly primaryLayerIds = ['background', 'user-areas'];
+
+  private initializePrimaryLayers() {
+    this.translateService.get(this.primaryLayerKeys).pipe(take(1)).subscribe(t => {
+      this.primaryLayers = this.primaryLayerIds.map((id, i) => ({
+        kind: 'primary' as const,
+        id,
+        name: t[this.primaryLayerKeys[i]],
+        visible: true,
+        opacity: 1,
+        instance: null
+      }));
+      this.cdr.markForCheck();
+    });
+  }
+
+  private updatePrimaryLayerNames() {
+    this.translateService.get(this.primaryLayerKeys).pipe(take(1)).subscribe(t => {
+      this.primaryLayers.forEach((layer, i) => {
+        layer.name = t[this.primaryLayerKeys[i]];
+      });
+      this.cdr.markForCheck();
+    });
+  }
+
+  public setPrimaryLayerInstances(instances: {
+    background?: LayerInstance,
+    userAreas?: LayerInstance
+  }) {
+    const layerMap: { [key: string]: LayerInstance | undefined } = {
+      'background': instances.background,
+      'user-areas': instances.userAreas
+    };
+
+    this.primaryLayers.forEach(layer => {
+      if (layerMap[layer.id] !== undefined) {
+        layer.instance = layerMap[layer.id]!;
+      }
+    });
+  }
+
+  getOpacity(item: LayerItem): number {
+    if (item.kind === 'primary') {
+      return item.opacity * 100;
+    } else if (item.kind === 'band') {
+      return this.layerStyleService.getOpacity(item.type, item.band.bandNumber) * 100;
+    } else {
+      return this.layerStyleService.getResultOpacity(item.entry.id) * 100;
+    }
+  }
+
+  toggleVisibility(item: LayerItem) {
+    if (item.kind === 'primary') {
+      item.visible = !item.visible;
+      item.instance?.setVisible?.(item.visible);
+    } else if (item.kind === 'band') {
+      item.visible = !item.visible;
+      this.layerStyleService.setBandVisibility(item.type, item.band.bandNumber, item.visible);
+    } else {
+      item.visible = !item.visible;
+      item.entry.layer.setVisible(item.visible);
+    }
+  }
+
+  changeOpacity(item: LayerItem, value: number) {
+    const opacity = value / 100;
+
+    if (item.kind === 'primary') {
+      item.opacity = opacity;
+      item.instance?.setOpacity?.(opacity);
+    } else if (item.kind === 'band') {
+      this.layerStyleService.setOpacity(item.type, item.band.bandNumber, opacity);
+    } else {
+      this.layerStyleService.setResultOpacity(item.entry.id, opacity);
+      item.entry.layer.setOpacity(opacity);
+    }
+  }
+
+  removeLayer(item: LayerItem) {
+    if (item.kind === 'band') {
+      this.nameOverrides.delete(item.id);
+      // Restore visibility before removing so the band appears correctly if re-added
+      this.layerStyleService.setBandVisibility(item.type, item.band.bandNumber, true);
+      // Delegate removal to the store (BandLayer reacts via selectVisibleBands)
+      this.store.dispatch(MetadataActions.setVisibility({ band: item.band, value: false }));
+    } else if (item.kind === 'result') {
+      this.nameOverrides.delete(item.id);
+      this.calcService.removeResultPixels(item.entry.id);
+      this.layerStyleService.clearResultOpacity(item.entry.id);
+    }
+  }
+
+  startEditing(item: LayerItem) {
+    if (!this.isRenamable(item)) {
+      return;
+    }
+    this.editingLayerId = item.id;
+    this.editingName = item.name;
+  }
+
+  cancelEditing() {
+    this.editingLayerId = null;
+    this.editingName = '';
+  }
+
+  saveLayerName(item: LayerItem) {
+    const trimmed = this.editingName.trim();
+    if (!trimmed || trimmed === item.name) {
+      this.cancelEditing();
+      return;
+    }
+
+    // Store name locally — never mutate store objects
+    this.nameOverrides.set(item.id, trimmed);
+    item.name = trimmed;
+
+    this.cancelEditing();
+  }
+
+  onEditKeydown(event: KeyboardEvent, item: LayerItem) {
+    if (event.key === 'Enter') {
+      this.saveLayerName(item);
+    } else if (event.key === 'Escape') {
+      this.cancelEditing();
+    }
+  }
+
+  drop(event: CdkDragDrop<(BandLayerItem | ResultLayerItem)[]>) {
+    moveItemInArray(this.secondaryLayers, event.previousIndex, event.currentIndex);
+
+    this.layerStyleService.reorderSecondaryLayers(
+      this.secondaryLayers.map(item =>
+        item.kind === 'band'
+          ? { kind: 'band' as const, type: item.type, bandNumber: item.band.bandNumber }
+          : { kind: 'result' as const, id: item.entry.id }
+      )
+    );
+  }
+
+  isPrimary(item: LayerItem): item is PrimaryLayerItem {
+    return item.kind === 'primary';
+  }
+
+  isRemovable(item: LayerItem): boolean {
+    return item.kind !== 'primary';
+  }
+
+  isDraggable(item: LayerItem): boolean {
+    return item.kind !== 'primary';
+  }
+
+  isRenamable(item: LayerItem): boolean {
+    return item.kind === 'result';
+  }
+}

--- a/frontend/src/app/map-view/main-view.component.spec.ts
+++ b/frontend/src/app/map-view/main-view.component.spec.ts
@@ -37,6 +37,9 @@ import { RouterModule } from "@angular/router";
 import { provideZonelessChangeDetection } from "@angular/core";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { AddScenarioAreasComponent } from "@src/app/map-view/scenario/add-scenario-areas/add-scenario-areas.component";
+import { LayerManagerComponent } from './layer-manager/layer-manager.component';
+import { AutoSelectDirective } from './layer-manager/auto-select.directive';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 describe('MainViewComponent', () => {
   let fixture: ComponentFixture<MainViewComponent>,
       component: MainViewComponent;
@@ -53,6 +56,7 @@ describe('MainViewComponent', () => {
         MatCheckboxModule,
         FormsModule,
         StoreModule.forRoot({},{}),
+        DragDropModule,
       ],
       declarations: [
         MainViewComponent,
@@ -73,7 +77,9 @@ describe('MainViewComponent', () => {
         CalculationHistoryComponent,
         ComparisonComponent,
         BatchProgressComponent,
-        AddScenarioAreasComponent
+        AddScenarioAreasComponent,
+        LayerManagerComponent,
+        AutoSelectDirective
       ],
       providers: [
         FormBuilder,

--- a/frontend/src/app/map-view/map-view.module.ts
+++ b/frontend/src/app/map-view/map-view.module.ts
@@ -41,6 +41,9 @@ import { ConfirmGenerateComparisonComponent } from './calculation-history/confir
 import { CompoundComparisonListDialogComponent } from '@src/app/map-view/compound-comparison-list-dialog/compound-comparison-list-dialog.component';
 import { DownloadCompoundComparisonDialogComponent } from './compound-comparison-list-dialog/download-compound-comparison-dialog/download-compound-comparison-dialog.component';
 import { ReliabilityLegendComponent } from "@src/app/map-view/reliability-legend/reliability-legend.component";
+import { LayerManagerComponent } from './layer-manager/layer-manager.component';
+import { AutoSelectDirective } from './layer-manager/auto-select.directive';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
   declarations: [
@@ -71,7 +74,9 @@ import { ReliabilityLegendComponent } from "@src/app/map-view/reliability-legend
     ConfirmGenerateComparisonComponent,
     CompoundComparisonListDialogComponent,
     DownloadCompoundComparisonDialogComponent,
-    ReliabilityLegendComponent
+    ReliabilityLegendComponent,
+    LayerManagerComponent,
+    AutoSelectDirective
   ],
   imports: [
     SharedModule,
@@ -82,7 +87,8 @@ import { ReliabilityLegendComponent } from "@src/app/map-view/reliability-legend
     MatProgressSpinnerModule,
     MatCheckboxModule,
     MatButtonModule,
-    MatRadioModule
+    MatRadioModule,
+    DragDropModule
   ],
   providers: [AnchorPipe, DialogService],
   exports: [MainViewComponent, ComparisonComponent]

--- a/frontend/src/app/map-view/map/layers/band-layer.ts
+++ b/frontend/src/app/map-view/map/layers/band-layer.ts
@@ -5,6 +5,7 @@ import { ImageStatic } from 'ol/source';
 import { AppSettings } from '@src/app/app.settings';
 import { StaticImageOptions } from '@data/calculation/calculation.interfaces';
 import { DataLayerService } from '@src/app/map-view/map/layers/data-layer.service';
+import { LayerStyleService } from '@src/app/map-view/map/layers/layer-style.service';
 import ImageSource from 'ol/source/Image';
 import { SymphonyLayerGroup } from "@src/app/map-view/map/layers/symphony-layer";
 import RenderEvent from "ol/render/Event";
@@ -35,9 +36,42 @@ class BandLayer extends SymphonyLayerGroup {
   constructor(private baseline: string,
               private dataLayerService: DataLayerService,
               private store: Store<State>,
+              private layerStyleService: LayerStyleService,
               antialias: boolean) {
     super();
     this.antialias = antialias;
+
+    // When opacity changes in LayerStyleService, apply immediately to loaded OL layers
+    this.layerStyleService.getOpacityChanges().subscribe(() => {
+      this.loadedBands.ecoComponents.forEach((layer, bandNumber) => {
+        layer.setOpacity(this.layerStyleService.getOpacity('ECOSYSTEM', bandNumber));
+      });
+      this.loadedBands.pressures.forEach((layer, bandNumber) => {
+        layer.setOpacity(this.layerStyleService.getOpacity('PRESSURE', bandNumber));
+      });
+    });
+
+    // When visibility changes in LayerStyleService, apply immediately to loaded OL layers
+    this.layerStyleService.getVisibilityChanges().subscribe(() => {
+      this.loadedBands.ecoComponents.forEach((layer, bandNumber) => {
+        layer.setVisible(this.layerStyleService.getBandVisibility('ECOSYSTEM', bandNumber));
+      });
+      this.loadedBands.pressures.forEach((layer, bandNumber) => {
+        layer.setVisible(this.layerStyleService.getBandVisibility('PRESSURE', bandNumber));
+      });
+    });
+
+    // When z-index order changes, apply immediately to loaded OL layers
+    this.layerStyleService.getZIndexChanges().subscribe(zIndexMap => {
+      this.loadedBands.ecoComponents.forEach((layer, bandNumber) => {
+        const zIndex = zIndexMap.get(`ecosystem-${bandNumber}`);
+        if (zIndex !== undefined) layer.setZIndex(zIndex);
+      });
+      this.loadedBands.pressures.forEach((layer, bandNumber) => {
+        const zIndex = zIndexMap.get(`pressure-${bandNumber}`);
+        if (zIndex !== undefined) layer.setZIndex(zIndex);
+      });
+    });
   }
 
   protected renderHandler = (evt: RenderEvent) => (evt.context! as CanvasRenderingContext2D).imageSmoothingEnabled = this.antialias;

--- a/frontend/src/app/map-view/map/layers/layer-style.service.ts
+++ b/frontend/src/app/map-view/map/layers/layer-style.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { BandType } from '@data/metadata/metadata.interfaces';
+
+@Injectable({ providedIn: 'root' })
+export class LayerStyleService {
+
+  // Opacity state for both bands and results, keyed by:
+  //   bands:   `${type.toLowerCase()}-${bandNumber}`  e.g. "ecosystem-3"
+  //   results: `result-${calculationId}`              e.g. "result-42"
+
+  private opacityMap = new Map<string, number>();
+  private opacitySubject = new BehaviorSubject<Map<string, number>>(new Map());
+
+  private visibilityMap = new Map<string, boolean>();
+  private visibilitySubject = new BehaviorSubject<Map<string, boolean>>(new Map());
+
+  private zIndexMap = new Map<string, number>();
+  private zIndexSubject = new BehaviorSubject<Map<string, number>>(new Map());
+
+  private bandKey(type: BandType, bandNumber: number): string {
+    return `${type.toLowerCase()}-${bandNumber}`;
+  }
+
+  private resultKey(id: number): string {
+    return `result-${id}`;
+  }
+
+  // --- Bands ---
+
+  setOpacity(type: BandType, bandNumber: number, opacity: number): void {
+    this.opacityMap.set(this.bandKey(type, bandNumber), opacity);
+    this.opacitySubject.next(new Map(this.opacityMap));
+  }
+
+  getOpacity(type: BandType, bandNumber: number): number {
+    return this.opacityMap.get(this.bandKey(type, bandNumber)) ?? 1;
+  }
+
+  getOpacityChanges(): Observable<Map<string, number>> {
+    return this.opacitySubject.asObservable();
+  }
+
+  setBandVisibility(type: BandType, bandNumber: number, visible: boolean): void {
+    this.visibilityMap.set(this.bandKey(type, bandNumber), visible);
+    this.visibilitySubject.next(new Map(this.visibilityMap));
+  }
+
+  getBandVisibility(type: BandType, bandNumber: number): boolean {
+    return this.visibilityMap.get(this.bandKey(type, bandNumber)) ?? true;
+  }
+
+  getVisibilityChanges(): Observable<Map<string, boolean>> {
+    return this.visibilitySubject.asObservable();
+  }
+
+  // --- Results ---
+
+  setResultOpacity(id: number, opacity: number): void {
+    this.opacityMap.set(this.resultKey(id), opacity);
+    this.opacitySubject.next(new Map(this.opacityMap));
+  }
+
+  getResultOpacity(id: number): number {
+    return this.opacityMap.get(this.resultKey(id)) ?? 1;
+  }
+
+  clearResultOpacity(id: number): void {
+    this.opacityMap.delete(this.resultKey(id));
+    this.opacitySubject.next(new Map(this.opacityMap));
+  }
+
+  // --- Z-Index / Layer Order ---
+
+  getZIndexChanges(): Observable<Map<string, number>> {
+    return this.zIndexSubject.asObservable();
+  }
+
+  reorderSecondaryLayers(orderedItems: Array<
+    { kind: 'band'; type: BandType; bandNumber: number } |
+    { kind: 'result'; id: number }
+  >): void {
+    const baseZIndex = 100;
+    const count = orderedItems.length;
+    orderedItems.forEach((item, index) => {
+      const key = item.kind === 'band'
+        ? this.bandKey(item.type, item.bandNumber)
+        : this.resultKey(item.id);
+      this.zIndexMap.set(key, baseZIndex + (count - 1 - index));
+    });
+    this.zIndexSubject.next(new Map(this.zIndexMap));
+  }
+}

--- a/frontend/src/app/map-view/map/layers/result-layer-group.ts
+++ b/frontend/src/app/map-view/map/layers/result-layer-group.ts
@@ -7,6 +7,8 @@ import Static from "ol/source/ImageStatic";
 import { SymphonyLayerGroup } from "@src/app/map-view/map/layers/symphony-layer";
 import { MapComponent } from "@src/app/map-view/map/map.component";
 import { AppSettings } from "@src/app/app.settings";
+import { LayerStyleService } from '@src/app/map-view/map/layers/layer-style.service';
+import { ResultLayerService } from '@src/app/map-view/map/layers/result-layer.service';
 
 export class ResultLayerGroup extends SymphonyLayerGroup {
 
@@ -24,7 +26,20 @@ export class ResultLayerGroup extends SymphonyLayerGroup {
     };
   }
 
-  constructor(private map: MapComponent) { super(); }
+  constructor(
+    private map: MapComponent,
+    private layerStyleService: LayerStyleService,
+    private resultLayerService: ResultLayerService
+  ) {
+    super();
+
+    this.layerStyleService.getZIndexChanges().subscribe(zIndexMap => {
+      this.calculationLayers.forEach((layer, calcId) => {
+        const zIndex = zIndexMap.get(`result-${calcId}`);
+        if (zIndex !== undefined) layer.setZIndex(zIndex);
+      });
+    });
+  }
 
   // TODO Clip result to scenario boundaries? Perhaps like so:
   // https://gis.stackexchange.com/questions/185881/clipping-tilelayer-with-georeferenced-polygon-clipping-mask
@@ -44,6 +59,12 @@ export class ResultLayerGroup extends SymphonyLayerGroup {
       this.calculationLayers.set(result.calculationId, cpl);
       imageLayers.push(cpl);
       this.setLayers(imageLayers);
+
+      this.resultLayerService.add({
+        id: result.calculationId,
+        name: `Result ${result.calculationId}`,
+        layer: cpl
+      });
     }
 
     this.layerChange();
@@ -55,12 +76,17 @@ export class ResultLayerGroup extends SymphonyLayerGroup {
     if(cl) {
       imageLayers.remove(cl);
       this.calculationLayers.delete(id);
+      this.resultLayerService.remove(id);
+      this.layerStyleService.clearResultOpacity(id);
     }
     this.setLayers(imageLayers);
     this.layerChange();
   }
 
   public clearResult() {
+    this.resultLayerService.clear();
+    // Clear opacity entries for all tracked results
+    this.calculationLayers.forEach((_, id) => this.layerStyleService.clearResultOpacity(id));
     this.calculationLayers = new Map<number, ImageLayer<Static>>();
     this.setLayers(new Collection<BaseLayer>());
     this.layerChange();
@@ -82,6 +108,14 @@ export class ResultLayerGroup extends SymphonyLayerGroup {
       });
       this.calculationLayers.set(calcId, chgLayer);
       layers.push(chgLayer);
+
+      // Re-register the rebuilt layer instance and restore preserved opacity
+      this.resultLayerService.add({
+        id: calcId,
+        name: `Result ${calcId}`,
+        layer: chgLayer
+      });
+      chgLayer.setOpacity(this.layerStyleService.getResultOpacity(calcId));
     });
     this.setLayers(new Collection(layers));
     this.changed();

--- a/frontend/src/app/map-view/map/layers/result-layer.service.ts
+++ b/frontend/src/app/map-view/map/layers/result-layer.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import ImageLayer from 'ol/layer/Image';
+import Static from 'ol/source/ImageStatic';
+
+export interface ResultEntry {
+  id: number;
+  name: string;
+  layer: ImageLayer<Static>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ResultLayerService {
+
+  private entries: ResultEntry[] = [];
+  private entriesSubject = new BehaviorSubject<ResultEntry[]>([]);
+  public results$: Observable<ResultEntry[]> = this.entriesSubject.asObservable();
+
+  add(entry: ResultEntry): void {
+    if (!this.entries.find(e => e.id === entry.id)) {
+      this.entries.push(entry);
+      this.entriesSubject.next([...this.entries]);
+    }
+  }
+
+  remove(id: number): void {
+    this.entries = this.entries.filter(e => e.id !== id);
+    this.entriesSubject.next([...this.entries]);
+  }
+
+  clear(): void {
+    this.entries = [];
+    this.entriesSubject.next([]);
+  }
+}

--- a/frontend/src/app/map-view/map/map-toolbar/map-toolbar.component.html
+++ b/frontend/src/app/map-view/map/map-toolbar/map-toolbar.component.html
@@ -17,6 +17,12 @@
   [label]="'map.toolbar.anti-alias-' + (hasImageSmoothing ? 'off' : 'on') | translate"
   [active]="hasImageSmoothing"
   (click)="onToggleSmooth()"></app-toolbar-button>
+<app-toolbar-button
+  icon="layer"
+  [label]="'map.toolbar.layer-manager' | translate"
+  [active]="layerManagerActive"
+  (click)="onToggleLayerManager()">
+</app-toolbar-button>
 <div style="position: relative;">
   <app-map-opacity-slider (opacityChange)="onClickSetMapOpacity($event)"></app-map-opacity-slider>
 </div>

--- a/frontend/src/app/map-view/map/map-toolbar/map-toolbar.component.ts
+++ b/frontend/src/app/map-view/map/map-toolbar/map-toolbar.component.ts
@@ -15,10 +15,12 @@ export class MapToolbarComponent implements OnDestroy {
 
   @Input() hasResults = false;
   @Input() drawIsActive = false;
+  @Input() layerManagerActive = false;
   @Output() zoomIn: EventEmitter<void> = new EventEmitter<void>();
   @Output() zoomOut: EventEmitter<void> = new EventEmitter<void>();
   @Output() clearResult: EventEmitter<void> = new EventEmitter<void>();
   @Output() toggleDraw: EventEmitter<void> = new EventEmitter<void>();
+  @Output() toggleLayerManager = new EventEmitter<void>();
 
   private readonly aliasingSubscription$: Subscription;
 
@@ -52,5 +54,9 @@ export class MapToolbarComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.aliasingSubscription$.unsubscribe();
+  }
+
+  onToggleLayerManager() {
+    this.toggleLayerManager.emit();
   }
 }

--- a/frontend/src/app/map-view/map/map.component.html
+++ b/frontend/src/app/map-view/map/map.component.html
@@ -6,7 +6,13 @@
   (clearResult)="clearResult()"
   (toggleDraw)="toggleDrawInteraction()"
   (setMapOpacity)="setMapOpacity($event)"
+  [layerManagerActive]="layerManagerExpanded"
+  (toggleLayerManager)="toggleLayerManager()"
 ></app-map-toolbar>
+<app-layer-manager
+  class="layer-manager-panel"
+  [isExpanded]="layerManagerExpanded">
+</app-layer-manager>
 <app-footer></app-footer>
 @if (!drawIsActive) {
   <div id="popup" class="ol-popup">

--- a/frontend/src/app/map-view/map/map.component.scss
+++ b/frontend/src/app/map-view/map/map.component.scss
@@ -6,9 +6,22 @@
   background: colors.$hav-darkcoldgrey;
   position: relative;
   height: calc(100vh - #{cns.$header-height});
+  width: 100%;
+  display: block;
+  overflow: hidden;
 
+  /* 🔹 Fix 1: ensure the map always fills the available area */
   #map {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
     height: 100%;
+    z-index: 0; /* base layer sits behind everything else */
+    background: #dfe6ed; /* light fallback color if tiles fail */
+
     -moz-user-select: all;
     -webkit-user-select: all;
     -ms-user-select: all;
@@ -23,27 +36,32 @@
     }
   }
 
+  /* 🔹 Map Toolbar: stays above everything */
   app-map-toolbar {
     position: absolute;
     top: 2rem;
     right: 0.8rem;
+    z-index: 2100;
   }
 
+  /* 🔹 OpenLayers popup styling */
   .ol-popup {
     position: absolute;
     background-color: white;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
     padding: 10px;
     border-radius: 4px;
     border: 1px solid #cccccc;
     top: -23px;
     left: 22px;
     min-width: 240px;
+    z-index: 2500;
 
-    &:after, &:before {
+    &:after,
+    &:before {
       top: 12px;
       border: solid transparent;
-      content: " ";
+      content: '';
       height: 0;
       width: 0;
       position: absolute;
@@ -82,10 +100,20 @@
   #area-options-menu {
     background-color: white;
     font-size: 1.3rem;
+    position: absolute;
+    bottom: 80px;
+    right: 20px;
+    z-index: 2100;
+    border-radius: 4px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 
     button {
       padding: 0.7rem 0.6rem;
       margin: 0.3rem;
+      border: none;
+      border-radius: 4px;
+      background: #f9f9f9;
+      cursor: pointer;
 
       &:hover {
         background-color: colors.$hav-lightturquoise;

--- a/frontend/src/app/map-view/map/map.component.spec.ts
+++ b/frontend/src/app/map-view/map/map.component.spec.ts
@@ -9,38 +9,55 @@ import {
   ToolbarButtonComponent,
   ToolbarZoomButtonsComponent
 } from './toolbar-button/toolbar-button.component';
+import { LayerManagerComponent } from '../layer-manager/layer-manager.component';
+import { AutoSelectDirective } from '../layer-manager/auto-select.directive';
 import { SharedModule } from '@shared/shared.module';
 import { TranslationSetupModule } from '@src/app/app-translation-setup.module';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { initialState as metadata } from '@data/metadata/metadata.reducers';
 import { initialState as area } from '@data/area/area.reducers';
 import { initialState as scenario } from '@data/scenario/scenario.reducers';
+import { initialState as calculation } from '@data/calculation/calculation.reducers';
+import { MetadataSelectors } from '@data/metadata';
+import { CalculationSelectors } from '@data/calculation';
 import { ChangeState, ScenarioLayer } from '@src/app/map-view/map/layers/scenario-layer';
 import { BandChange } from '@data/metadata/metadata.interfaces';
 import { provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 describe('MapComponent', () => {
   let fixture: ComponentFixture<MapComponent>, component: MapComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, CoreModule, TranslationSetupModule],
+      imports: [SharedModule, CoreModule, TranslationSetupModule, DragDropModule],
       declarations: [
         MapComponent,
         MapToolbarComponent,
         MapOpacitySliderComponent,
         ToolbarZoomButtonsComponent,
-        ToolbarButtonComponent
+        ToolbarButtonComponent,
+        LayerManagerComponent,
+        AutoSelectDirective
       ],
       providers: [
         provideMockStore({
           initialState: {
-            metadata: metadata,
-            area: area,
-            scenario: scenario,
+            metadata,
+            area,
+            scenario,
+            calculation,
             user: { baseline: undefined }
-          }
+          },
+          selectors: [
+            { selector: MetadataSelectors.selectVisibleBands, value: { ecoComponent: [], pressureComponent: [] } },
+            { selector: CalculationSelectors.selectCalculations, value: [] }
+          ]
         }),
-        provideZonelessChangeDetection()
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting()
       ]
     }).compileComponents();
     fixture = TestBed.createComponent(MapComponent);

--- a/frontend/src/app/map-view/map/map.component.ts
+++ b/frontend/src/app/map-view/map/map.component.ts
@@ -42,6 +42,8 @@ import { ScenarioLayer } from '@src/app/map-view/map/layers/scenario-layer';
 import AreaLayer from '@src/app/map-view/map/layers/area-layer';
 import { Extent } from 'ol/extent';
 import { DataLayerService } from '@src/app/map-view/map/layers/data-layer.service';
+import { LayerStyleService } from '@src/app/map-view/map/layers/layer-style.service';
+import { ResultLayerService } from '@src/app/map-view/map/layers/result-layer.service';
 import { isEqual } from '@shared/common.util';
 import { dieCutPolygons, turfMergeAll } from '@shared/turf-helper/turf-helper';
 import { SelectIntersectionComponent } from '@shared/select-intersection/select-intersection.component';
@@ -53,6 +55,7 @@ import { AreaSelectionConfig } from '@shared/select-intersection/select-intersec
 import { AreaHighlightLayer } from '@src/app/map-view/map/layers/area-highlight-layer';
 import { ReliabilityLayer } from '@src/app/map-view/map/layers/reliability-layer';
 import { BandType, ReliabilityMap } from '@data/metadata/metadata.interfaces';
+import { LayerManagerComponent } from '../layer-manager/layer-manager.component';
 import { MapViewModule } from '@src/app/map-view/map-view.module';
 import { ScenarioService } from '@data/scenario/scenario.service';
 
@@ -69,6 +72,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly translateService = inject(TranslateService);
   private readonly dataLayerService = inject(DataLayerService);
   private readonly scenarioService = inject(ScenarioService);
+  private readonly layerStyleService = inject(LayerStyleService);
+  private readonly resultLayerService = inject(ResultLayerService);
 
   @Input() mapCenter?: Coordinate;
   @Output() resultLayerGroupChange: EventEmitter<number> = new EventEmitter<number>();
@@ -76,6 +81,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   drawIsActive = false;
 
   @ViewChild('areaOptionsMenu') areaOptionsMenu!: ElementRef<HTMLElement>;
+  @ViewChild(LayerManagerComponent) layerManager?: LayerManagerComponent;
+  layerManagerExpanded = false; // Start minimized
 
   private map?: OLMap;
   private readonly storeSubscription?: Subscription;
@@ -228,7 +235,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         .pipe(skipWhile((value) => !value || value.features.length === 0))
     );
 
-    this.resultLayerGroup = new ResultLayerGroup(this);
+    this.resultLayerGroup = new ResultLayerGroup(this, this.layerStyleService, this.resultLayerService);
     this.map.addLayer(this.resultLayerGroup);
     this.geoJson = new GeoJSON({
       featureProjection: this.map.getView().getProjection()
@@ -333,6 +340,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           baseline.name,
           this.dataLayerService,
           this.store,
+          this.layerStyleService,
           this.aliasing
         );
         this.map!.getLayers().insertAt(1, this.bandLayer); // on top of background layer
@@ -340,11 +348,22 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         this.areaLayer.deselectAreas();
         this.clearResult();
       });
+
+    setTimeout(() => {
+      this.layerManager?.setPrimaryLayerInstances({
+        background: this.background,
+        userAreas: this.areaLayer
+      });
+    }, 0);
   }
 
   public clearResult() {
     this.resultLayerGroup.clearResult();
     this.store.dispatch(CalculationActions.resetComparisonLegend());
+  }
+
+  public toggleLayerManager() {
+    this.layerManagerExpanded = !this.layerManagerExpanded;
   }
 
   public highlightArea = (statePath: StatePath, highlight: boolean) => {

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -15,6 +15,26 @@
         }
     },
     "map": {
+        "layer-manager": {
+            "title": "Layer Manager",
+            "info": "Manage visibility, order, and opacity of map layers",
+            "sections": {
+            "map-layers": "Map Layers",
+            "active-layers": "Active Layers"
+            },
+            "tooltips": {
+            "toggle-visibility": "Toggle layer visibility",
+            "adjust-opacity": "Adjust layer opacity",
+            "reorder-layer": "Drag to reorder layer",
+            "remove-layer": "Remove layer from map",
+            "rename-layer": "Click to rename layer",
+            "confirm-rename": "Confirm rename"
+            },
+            "layer-names": {
+            "background": "Background",
+            "user-areas": "User Areas"
+            }
+        },
         "background-transparency": "Background map transparency",
         "click-area": "Click to select area.",
         "location-within-scenario": "The area overlaps with the active scenario.",

--- a/frontend/src/assets/i18n/sv.json
+++ b/frontend/src/assets/i18n/sv.json
@@ -15,6 +15,26 @@
         }
     },
     "map": {
+        "layer-manager": {
+            "title": "Lagerhanterare",
+            "info": "Hantera synlighet, ordning och opacitet för kartlager",
+            "sections": {
+            "map-layers": "Kartlager",
+            "active-layers": "Aktiva lager"
+            },
+            "tooltips": {
+            "toggle-visibility": "Växla lagersynlighet",
+            "adjust-opacity": "Justera lageropacitet",
+            "reorder-layer": "Dra för att ändra ordning",
+            "remove-layer": "Ta bort lager från kartan",
+            "rename-layer": "Klicka för att byt namn",
+            "confirm-rename": "Bekräfta namnbyte"
+            },
+            "layer-names": {
+            "background": "Bakgrund",
+            "user-areas": "Användarområden"
+            }
+        },
         "background-transparency": "Bakgrundskartans synlighet",
         "click-area": "Klicka för att markera området.",
         "location-within-scenario": "Området överlappar med det aktiva scenariot.",


### PR DESCRIPTION
This PR is part of a bachelor's thesis at Chalmers University of Technology (Department of Mechanical Engineering), carried out together with HaV and building on the Mistra C2B2 hackathon. It's the first of a few feature contributions we hope to upstream, feedback is very welcome and we're glad to adjust to your conventions.

## Layer Manager
Adds a draggable Layer Manager window to the map view, giving an overview of all active map layers with controls for visibility, opacity, ordering and (local) renaming. Opened from a toggle in the map toolbar.

### Features
- **Two sections:**
  - *Map Layers* — the primary OL layers (Background, User Areas).
  - *Active Layers* — bands (ecosystem / pressure) and result layers from previous calculations.
- Per-layer **visibility toggle** and **opacity slider**.
- **Click-to-rename on result layers** — local to the manager; does not affect the underlying band titles or calculation names.
- **Drag-to-reorder** within *Active Layers* (cdkDropList), letting the user choose the overlapping visual order on the map.
- **Draggable window** (cdkDrag) with a fixed default position on open; shown/hidden from the map toolbar.
- Full i18n (sv/en) under `map.layer-manager.*`.

### Changes made
- New `LayerManagerComponent` (+ `AutoSelectDirective`) in `map-view/layer-manager/`.
- New `LayerStyleService` and `ResultLayerService` under `map-view/map/layers/` (both introduced in this PR).
- New toolbar toggle in `map-toolbar` and wiring in `map.component.html`.
- Layer model expressed as a discriminated union `LayerItem = PrimaryLayerItem | BandLayerItem | ResultLayerItem`, with a `kind` field driving polymorphic visibility / opacity / rename handlers in the template.
- Primary OL layer instances are passed from `MapComponent` to `LayerManagerComponent` via `@ViewChild` once the view is initialised.
- Translations added to `frontend/src/assets/i18n/{sv,en}.json`.

### Dependencies
- Bands are read from the NgRx store via `MetadataSelectors`; result layers via `ResultLayerService`; per-layer opacity state via `LayerStyleService`.
- Uses Angular CDK `drag-drop` (already a project dependency).
- No new backend, schema, or third-party dependencies.

### Known issues / out of scope
- Renames are in-memory only and reset on reload. Per-user persistence was discussed but considered unwanted.
- The initial order of the first two items can appear swapped; it corrects itself once any item is reordered.

### Notes for review
- The Layer Manager sets layer state imperatively inside subscriptions. Under Angular 21's zoneless change detection we trigger view refresh with `ChangeDetectorRef.markForCheck()` rather than converting the streams to signals — kept deliberately minimal, but happy to move to a signal-based approach if you prefer that idiom.
- Renaming is intentionally shallow (manager-local state only); it does not mutate `Band.title` or any calculation/result name in stores or services.
- The existing Background opacity control is left in place and is now also covered by the manager — flagging in case you'd rather remove the redundancy.
- Our developing environment has been removed.