### PR TITLE
Allow missing 'code' property in selectable areas

### DIFF
--- a/frontend/src/app/data/area/area.effects.ts
+++ b/frontend/src/app/data/area/area.effects.ts
@@ -241,7 +241,7 @@ function flattenAreaGroups(nationalArea: NationalArea, language: string): Nation
 function flattenAreas(areas: Area[], parentPath: StatePath): Areas {
   return areas.reduce((prevAreas, area) => {
     const statePath = [...parentPath, 'areas', area.name];
-    const displayName =  `${area.name} (${area.code})`;
+    const displayName =  area.name + (area.code ? ` (${area.code})` : '');
     return {
       ...prevAreas,
       [area.name]: {
@@ -254,7 +254,7 @@ function flattenAreas(areas: Area[], parentPath: StatePath): Areas {
           displayName,
           statePath,
           area.polygon,
-          area.code
+          area.code || ''
         )
       }
     };

--- a/frontend/src/app/data/area/area.interfaces.ts
+++ b/frontend/src/app/data/area/area.interfaces.ts
@@ -19,7 +19,7 @@ export interface SelectableArea {
 }
 
 export interface Area extends SelectableArea {
-  code: string;
+  code?: string | null;
   searchdata: string;
   areaKm2: number;
 }


### PR DESCRIPTION
Minor change, addressing inadequate rendering of area names lists on the front end.